### PR TITLE
Support deploying docker apps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-deployer-resource-docker</artifactId>
+				<version>${spring-cloud-deployer.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-spi-test</artifactId>
 				<version>${spring-cloud-deployer.version}</version>
 				<scope>test</scope>

--- a/spring-cloud-deployer-local/pom.xml
+++ b/spring-cloud-deployer-local/pom.xml
@@ -24,6 +24,10 @@
 			<artifactId>spring-cloud-deployer-resource-maven</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-deployer-resource-docker</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/CommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/CommandBuilder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.local;
+
+import java.util.Map;
+
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+
+/**
+ * Strategy interface for Execution Command builder.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public interface CommandBuilder {
+
+	/**
+	 * Builds the execution command for an application.
+	 *
+	 * @param request the request for the application to execute
+	 * @param args the properties to use when building the execution command
+	 * @return the build command as a string array
+	 */
+	String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> args);
+}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.local;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.deployer.resource.docker.DockerResource;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+public class DockerCommandBuilder implements CommandBuilder {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	@Override
+	public String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> args) {
+		List<String> commands = addDockerOptions(request, args);
+		logger.debug("Docker Command = " + commands);
+		return commands.toArray(new String[0]);
+	}
+
+	private List<String> addDockerOptions(AppDeploymentRequest request, Map<String, String> args) {
+		List<String> commands = new ArrayList<>();
+		commands.add("docker");
+		commands.add("run");
+		DockerResource dockerResource = (DockerResource) request.getResource();
+		for (Map.Entry<String, String> entry : args.entrySet()) {
+			commands.add("-e");
+			commands.add(String.format("%s=%s", entry.getKey(), entry.getValue()));
+		}
+		try {
+			String dockerImageURI = dockerResource.getURI().toString();
+			commands.add(dockerImageURI.substring("docker:".length()));
+		}
+		catch (IOException e) {
+			throw new IllegalStateException(e);
+		}
+		return commands;
+	}
+}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/ExecutionCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/ExecutionCommandBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.deployer.spi.local;
 
+import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.util.ByteSizeUtils;
@@ -34,6 +35,7 @@ import static org.springframework.cloud.deployer.spi.local.LocalDeployerProperti
  * A class to help create the execution command for launching a Java Process.
  *
  * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
  */
 public class ExecutionCommandBuilder {
 
@@ -89,6 +91,23 @@ public class ExecutionCommandBuilder {
             catch (IOException e) {
                 throw new IllegalStateException(e);
             }
+        }
+    }
+
+    public void addDockerOptions(List<String> commands, AppDeploymentRequest request, Map<String, String> args) {
+        commands.add("docker");
+        commands.add("run");
+        DockerResource dockerResource = (DockerResource) request.getResource();
+        for (Map.Entry<String, String> entry: args.entrySet()) {
+            commands.add("-e");
+            commands.add(String.format("%s=%s", entry.getKey(), entry.getValue()));
+        }
+        try {
+            String dockerImageURI = dockerResource.getURI().toString();
+            commands.add(dockerImageURI.substring("docker:".length()));
+        }
+        catch (IOException e) {
+            throw new IllegalStateException(e);
         }
     }
 

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/JavaCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/JavaCommandBuilder.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.local;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.util.ByteSizeUtils;
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.cloud.deployer.spi.local.LocalDeployerProperties.PREFIX;
+
+/**
+ * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
+ */
+public class JavaCommandBuilder implements CommandBuilder {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	private static final String MAIN = "main";
+
+	private static final String CLASSPATH = "classpath";
+
+	private LocalDeployerProperties properties;
+
+	public JavaCommandBuilder(LocalDeployerProperties properties) {
+		this.properties = properties;
+	}
+
+	@Override
+	public String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> args) {
+		ArrayList<String> commands = new ArrayList<String>();
+		Map<String, String> deploymentProperties = request.getDeploymentProperties();
+		commands.add(properties.getJavaCmd());
+		// Add Java System Properties (ie -Dmy.prop=val) before main class or -jar
+		addJavaOptions(commands, deploymentProperties, properties);
+		addJavaExecutionOptions(commands, request);
+		commands.addAll(request.getCommandlineArguments());
+		logger.debug("Java Command = " + commands);
+		return commands.toArray(new String[0]);
+	}
+
+	protected void addJavaOptions(List<String> commands, Map<String, String> deploymentProperties,
+			LocalDeployerProperties localDeployerProperties) {
+		String memory = null;
+		if (deploymentProperties.containsKey(AppDeployer.MEMORY_PROPERTY_KEY)) {
+			memory = "-Xmx" +
+					ByteSizeUtils.parseToMebibytes(deploymentProperties.get(AppDeployer.MEMORY_PROPERTY_KEY)) + "m";
+		}
+
+		String javaOptsString = getValue(deploymentProperties, "javaOpts");
+		if (javaOptsString == null && memory != null) {
+			commands.add(memory);
+		}
+
+		if (javaOptsString != null) {
+			String[] javaOpts = StringUtils.tokenizeToStringArray(javaOptsString, " ");
+			boolean noJavaMemoryOption = !Stream.of(javaOpts).anyMatch(s -> s.startsWith("-Xmx"));
+			if (noJavaMemoryOption && memory != null) {
+				commands.add(memory);
+			}
+			commands.addAll(Arrays.asList(javaOpts));
+		}
+		else {
+			if (localDeployerProperties.getJavaOpts() != null) {
+				String[] javaOpts = StringUtils.tokenizeToStringArray(localDeployerProperties.getJavaOpts(), " ");
+				commands.addAll(Arrays.asList(javaOpts));
+			}
+		}
+	}
+
+	protected void addJavaExecutionOptions(List<String> commands, AppDeploymentRequest request) {
+		Map<String, String> deploymentProperties = request.getDeploymentProperties();
+		if (containsKey(deploymentProperties, MAIN) || containsKey(deploymentProperties, CLASSPATH)) {
+			Assert.isTrue(containsKey(deploymentProperties, MAIN)
+							&& containsKey(deploymentProperties, CLASSPATH),
+					PREFIX + "." + MAIN + " and " + PREFIX + "." + CLASSPATH +
+							" deployment properties are both required if either is provided.");
+			commands.add("-cp");
+			commands.add(getValue(deploymentProperties, CLASSPATH));
+			commands.add(getValue(deploymentProperties, MAIN));
+		}
+		else {
+			commands.add("-jar");
+			Resource resource = request.getResource();
+			try {
+				commands.add(resource.getFile().getAbsolutePath());
+			}
+			catch (IOException e) {
+				throw new IllegalStateException(e);
+			}
+		}
+	}
+
+	private boolean containsKey(Map<String, String> deploymentProperties, String propertyName) {
+		return deploymentProperties.containsKey(PREFIX + "." + propertyName);
+	}
+
+	private String getValue(Map<String, String> deploymentProperties, String propertyName) {
+		return deploymentProperties.get(PREFIX + "." + propertyName);
+	}
+
+}

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/ExecutionCommandBuilderTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/ExecutionCommandBuilderTests.java
@@ -41,14 +41,14 @@ import static org.springframework.cloud.deployer.spi.local.LocalDeployerProperti
 
 public class ExecutionCommandBuilderTests {
 
-    private ExecutionCommandBuilder commandBuilder;
+    private JavaCommandBuilder commandBuilder;
     private List<String> args;
     private Map<String, String> deploymentProperties;
     private LocalDeployerProperties localDeployerProperties;
 
     @Before
     public void setUp() {
-        commandBuilder = new ExecutionCommandBuilder();
+        commandBuilder = new JavaCommandBuilder(localDeployerProperties);
         args = new ArrayList<>();
         deploymentProperties = new HashMap<>();
         localDeployerProperties = new LocalDeployerProperties();


### PR DESCRIPTION
     - If the deployment resource is of `DockerResource` then use docker options instead of java options
     - Update the args as environment variables for docker apps

This resolves #6