### PR TITLE
Fix undeploy failure

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -17,24 +17,17 @@
 package org.springframework.cloud.deployer.spi.local;
 
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.springframework.cglib.core.Local;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
-import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -150,11 +143,12 @@ public abstract class AbstractLocalDeployerSupport {
 				}
 			}
 		}
-		catch (ResourceAccessException e) {
-			// ignore I/O errors
-		}
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
+		}
+		catch (Exception e) {
+			// ignore all other errors as we're going to
+			// destroy process if it's alive
 		}
 		finally {
 			if (isAlive(instance.getProcess())) {

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -63,6 +63,8 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 
 	private static final String JMX_DEFAULT_DOMAIN_KEY = "spring.jmx.default-domain";
 
+	private static final String ENDPOINTS_SHUTDOWN_ENABLED_KEY = "endpoints.shutdown.enabled";
+
 	private static final int DEFAULT_SERVER_PORT = 8080;
 
 	private final Map<String, List<AppInstance>> running = new ConcurrentHashMap<>();
@@ -97,7 +99,9 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 		HashMap<String, String> args = new HashMap<>();
 		args.putAll(request.getDefinition().getProperties());
 		args.put(JMX_DEFAULT_DOMAIN_KEY, deploymentId);
-		args.put("endpoints.shutdown.enabled", "true");
+		if (!request.getDefinition().getProperties().containsKey(ENDPOINTS_SHUTDOWN_ENABLED_KEY)) {
+			args.put(ENDPOINTS_SHUTDOWN_ENABLED_KEY, "true");
+		}
 		args.put("endpoints.jmx.unique-names", "true");
 		if (group != null) {
 			args.put("spring.cloud.application.group", group);


### PR DESCRIPTION
- Don't force 'endpoints.shutdown.enabled' for local app
  if it's given via deploy props. Helps for testing and
  allows user to disable shutdown. Default functionality
  is same as before.
- Catch all errors after possible thread interrupt as
  process is going to get killed anyway.
- Add test which disables shutdown endpoint for an app and
  makes sure that undeploy goes through without errors.
- Fixes #13