### PR TITLE
Docker command builder should support custom container names

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.deployer.spi.local;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -123,15 +124,15 @@ public abstract class AbstractLocalDeployerSupport {
 	 * @param args the args
 	 * @return the process builder
 	 */
-	protected ProcessBuilder buildProcessBuilder(AppDeploymentRequest request, Map<String, String> args) {
+	protected ProcessBuilder buildProcessBuilder(AppDeploymentRequest request, Map<String, String> args, Optional<Integer> appInstanceNumber) {
 		Assert.notNull(request, "AppDeploymentRequest must be set");
 		Assert.notNull(args, "Args must be set");
 		String[] commands = null;
 		if (request.getResource() instanceof DockerResource) {
-			commands = this.dockerCommandBuilder.buildExecutionCommand(request, args);
+			commands = this.dockerCommandBuilder.buildExecutionCommand(request, args, appInstanceNumber);
 		}
 		else {
-			commands = this.javaCommandBuilder.buildExecutionCommand(request, args);
+			commands = this.javaCommandBuilder.buildExecutionCommand(request, args, appInstanceNumber);
 		}
 		ProcessBuilder builder = new ProcessBuilder(commands);
 		retainEnvVars(builder.environment().keySet());

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/CommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/CommandBuilder.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.deployer.spi.local;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 
@@ -33,5 +34,5 @@ public interface CommandBuilder {
 	 * @param args the properties to use when building the execution command
 	 * @return the build command as a string array
 	 */
-	String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> args);
+	String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> args, Optional<Integer> appInstanceNumber);
 }

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
@@ -53,16 +53,17 @@ public class DockerCommandBuilder implements CommandBuilder {
 			if (entry.getKey().equals(LocalAppDeployer.SERVER_PORT_KEY)) {
 				commands.add("-p");
 				commands.add(String.format("%s:8080", args.get(entry.getKey())));
-			} else if (entry.getKey().equals(DOCKER_CONTAINER_NAME_KEY)) {
-				if(appInstanceNumber.isPresent()) {
-					commands.add(String.format("--name=%s-%d", entry.getValue(), appInstanceNumber.get()));
-				} else {
-					commands.add(String.format("--name=%s", args.get(entry.getValue())));
-				}
 			}
 			else {
 				commands.add("-e");
 				commands.add(String.format("%s=%s", entry.getKey(), entry.getValue()));
+			}
+		}
+		if(request.getDeploymentProperties().containsKey(DOCKER_CONTAINER_NAME_KEY)) {
+			if(appInstanceNumber.isPresent()) {
+				commands.add(String.format("--name=%s-%d", request.getDeploymentProperties().get(DOCKER_CONTAINER_NAME_KEY), appInstanceNumber.get()));
+			} else {
+				commands.add(String.format("--name=%s", request.getDeploymentProperties().get(DOCKER_CONTAINER_NAME_KEY)));
 			}
 		}
 		try {

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 
 /**
@@ -32,7 +33,7 @@ import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
  */
 public class DockerCommandBuilder implements CommandBuilder {
 
-	private static final String DOCKER_CONTAINER_NAME_KEY = "docker.container.name";
+	private static final String DOCKER_CONTAINER_NAME_KEY = AppDeployer.PREFIX + "docker.container.name";
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/JavaCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/JavaCommandBuilder.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -53,7 +54,7 @@ public class JavaCommandBuilder implements CommandBuilder {
 	}
 
 	@Override
-	public String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> args) {
+	public String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> args, Optional<Integer> appInstanceNumber) {
 		ArrayList<String> commands = new ArrayList<String>();
 		Map<String, String> deploymentProperties = request.getDeploymentProperties();
 		commands.add(properties.getJavaCmd());

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -131,7 +132,7 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 				if (useDynamicPort) {
 					args.put(SERVER_PORT_KEY, String.valueOf(port));
 				}
-				ProcessBuilder builder = buildProcessBuilder(request, args);
+				ProcessBuilder builder = buildProcessBuilder(request, args, Optional.of(i));
 				AppInstance instance = new AppInstance(deploymentId, i, builder, workDir, port);
 				processes.add(instance);
 				if (getLocalDeployerProperties().isDeleteFilesOnExit()) {

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncher.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncher.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -108,7 +109,7 @@ public class LocalTaskLauncher extends AbstractLocalDeployerSupport implements T
 			if (useDynamicPort) {
 				args.put(SERVER_PORT_KEY, String.valueOf(port));
 			}
-			ProcessBuilder builder = buildProcessBuilder(request, args);
+			ProcessBuilder builder = buildProcessBuilder(request, args, Optional.empty());
 			TaskInstance instance = new TaskInstance(builder, workDir, port);
 			running.put(taskLaunchId, instance);
 			if (getLocalDeployerProperties().isDeleteFilesOnExit()) {


### PR DESCRIPTION
Hi,

What do you think about providing some control over the name assigned to created Docker containers? In particular I'd highly appreciate an ability to provide a property which will indicate the name of the created container.

For example for property `docker.container.name=myapp` and `spring.cloud.deployer.count=3`, I'd like to have three containers created with the following names:
```
myapp-0
myapp-1
myapp-2
```

Such addition will be extremely useful for development and test environments, as many existing dev/QA tools and scripts make some assumptions about the containers names.

Cheers!