### PR TITLE
Add escaping on windows

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -134,6 +134,14 @@ public abstract class AbstractLocalDeployerSupport {
 		else {
 			commands = this.javaCommandBuilder.buildExecutionCommand(request, args, appInstanceNumber);
 		}
+
+		// tweak escaping double quotes needed for windows
+		if (LocalDeployerUtils.isWindows()) {
+			for (int i = 0; i < commands.length; i++) {
+				commands[i] = commands[i].replace("\"", "\\\"");
+			}
+		}
+
 		ProcessBuilder builder = new ProcessBuilder(commands);
 		retainEnvVars(builder.environment().keySet());
 		builder.environment().putAll(args);

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -51,7 +51,7 @@ public class LocalDeployerProperties {
 
 	private static final Logger logger = LoggerFactory.getLogger(LocalDeployerProperties.class);
 
-	private static final String JAVA_COMMAND = isWindows() ? "java.exe" : "java";
+	private static final String JAVA_COMMAND = LocalDeployerUtils.isWindows() ? "java.exe" : "java";
 
 	/**
 	 * Directory in which all created processes will run and create log files.
@@ -151,20 +151,6 @@ public class LocalDeployerProperties {
 		}
 
 		return javaExecutablePath;
-	}
-
-	private static boolean isWindows() {
-		String osName = null;
-		try {
-			osName = System.getProperty("os.name");
-		} catch (Exception e) {
-		}
-		if (osName == null) {
-			return false;
-		}
-		else {
-			return osName.toLowerCase().startsWith("windows");
-		}
 	}
 
 	@Override

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerUtils.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.local;
+
+/**
+ * Deployer utility functions.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class LocalDeployerUtils {
+
+	/**
+	 * Checks if jvm is running on windows.
+	 *
+	 * @return true if windows detected
+	 */
+	protected static boolean isWindows() {
+		String osName = null;
+		try {
+			osName = System.getProperty("os.name");
+		} catch (Exception e) {
+		}
+		if (osName == null) {
+			return false;
+		}
+		else {
+			return osName.toLowerCase().startsWith("windows");
+		}
+	}
+}


### PR DESCRIPTION
- When passing double quotes into processbuilder,
  those needs to be escaped with backslash.
- Moved win detection function to its own utility
  class with protected access as its solely for
  our own usage.
- Fixes #63