### PR TITLE
Fix local deployer issues

### DIFF
--- a/spring-cloud-deployer-local/pom.xml
+++ b/spring-cloud-deployer-local/pom.xml
@@ -36,6 +36,10 @@
 			<artifactId>spring-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -17,12 +17,19 @@
 package org.springframework.cloud.deployer.spi.local;
 
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
@@ -44,6 +51,11 @@ import org.springframework.web.client.RestTemplate;
  */
 public abstract class AbstractLocalDeployerSupport {
 
+	public static final String USE_SPRING_APPLICATION_JSON_KEY =
+			LocalDeployerProperties.PREFIX + ".use-spring-application-json";
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
 	protected final Logger logger = LoggerFactory.getLogger(getClass());
 
 	private final LocalDeployerProperties properties;
@@ -53,6 +65,9 @@ public abstract class AbstractLocalDeployerSupport {
 	private final JavaCommandBuilder javaCommandBuilder;
 
 	private final DockerCommandBuilder dockerCommandBuilder;
+
+	private String[] envVarsSetByDeployer =
+			{"SPRING_CLOUD_APPLICATION_GUID", "SPRING_APPLICATION_INDEX", "INSTANCE_INDEX"};
 
 	/**
 	 * Instantiates a new abstract deployer support.
@@ -100,7 +115,9 @@ public abstract class AbstractLocalDeployerSupport {
 	 * @param vars set of environment variable strings
 	 */
 	protected void retainEnvVars(Set<String> vars) {
-		String[] patterns = getLocalDeployerProperties().getEnvVarsToInherit();
+
+		List<String> patterns = new ArrayList<>(Arrays.asList(getLocalDeployerProperties().getEnvVarsToInherit()));
+		patterns.addAll(Arrays.asList(this.envVarsSetByDeployer));
 
 		for (Iterator<String> iterator = vars.iterator(); iterator.hasNext();) {
 			String var = iterator.next();
@@ -130,11 +147,16 @@ public abstract class AbstractLocalDeployerSupport {
 		Assert.notNull(request, "AppDeploymentRequest must be set");
 		Assert.notNull(appProperties, "Args must be set");
 		String[] commands = null;
+		Map<String, String> appInstanceEnvToUse = new HashMap<>(appInstanceEnv);
+		Map<String, String> appPropertiesToUse = new HashMap<>();
+		handleAppPropertiesPassing(request, appProperties, appInstanceEnvToUse, appPropertiesToUse);
 		if (request.getResource() instanceof DockerResource) {
-			commands = this.dockerCommandBuilder.buildExecutionCommand(request, appInstanceEnv, appProperties, appInstanceNumber);
+			commands = this.dockerCommandBuilder.buildExecutionCommand(request,
+					appInstanceEnvToUse, appPropertiesToUse, appInstanceNumber);
 		}
 		else {
-			commands = this.javaCommandBuilder.buildExecutionCommand(request, appInstanceEnv, appProperties, appInstanceNumber);
+			commands = this.javaCommandBuilder.buildExecutionCommand(request,
+					appInstanceEnvToUse, appPropertiesToUse, appInstanceNumber);
 		}
 
 		// tweak escaping double quotes needed for windows
@@ -150,6 +172,28 @@ public abstract class AbstractLocalDeployerSupport {
 		}
 		retainEnvVars(builder.environment().keySet());
 		return builder;
+	}
+
+	protected void handleAppPropertiesPassing(AppDeploymentRequest request, Map<String, String> appProperties,
+											  Map<String, String> appInstanceEnvToUse,
+											  Map<String, String> appPropertiesToUse) {
+		if (useSpringApplicationJson(request)) {
+			try {
+				appInstanceEnvToUse.putAll(Collections.singletonMap(
+						"SPRING_APPLICATION_JSON", OBJECT_MAPPER.writeValueAsString(appProperties)));
+			} catch (JsonProcessingException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		else {
+			appPropertiesToUse.putAll(appProperties);
+		}
+	}
+
+	private boolean useSpringApplicationJson(AppDeploymentRequest request) {
+		return Optional.ofNullable(request.getDeploymentProperties().get(USE_SPRING_APPLICATION_JSON_KEY))
+				.map(Boolean::valueOf)
+				.orElse(this.properties.isUseSpringApplicationJson());
 	}
 
 	/**

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/CommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/CommandBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
  * Strategy interface for Execution Command builder.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Thomas Risberg
  */
 public interface CommandBuilder {
 
@@ -31,8 +32,12 @@ public interface CommandBuilder {
 	 * Builds the execution command for an application.
 	 *
 	 * @param request the request for the application to execute
-	 * @param args the properties to use when building the execution command
+	 * @param appInstanceEnv the env vars tha might be needed when building the execution command
+	 * @param appProperties the app properties to use when building the execution command
 	 * @return the build command as a string array
 	 */
-	String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> args, Optional<Integer> appInstanceNumber);
+	String[] buildExecutionCommand(AppDeploymentRequest request,
+								   Map<String, String> appInstanceEnv,
+								   Map<String, String> appProperties,
+								   Optional<Integer> appInstanceNumber);
 }

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/JavaCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/JavaCommandBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import static org.springframework.cloud.deployer.spi.local.LocalDeployerProperti
 /**
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
+ * @author Thomas Risberg
  */
 public class JavaCommandBuilder implements CommandBuilder {
 
@@ -54,13 +55,18 @@ public class JavaCommandBuilder implements CommandBuilder {
 	}
 
 	@Override
-	public String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> args, Optional<Integer> appInstanceNumber) {
+	public String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> appInstanceEnv,
+										  Map<String, String> appProperties, Optional<Integer> appInstanceNumber) {
 		ArrayList<String> commands = new ArrayList<String>();
 		Map<String, String> deploymentProperties = request.getDeploymentProperties();
 		commands.add(properties.getJavaCmd());
 		// Add Java System Properties (ie -Dmy.prop=val) before main class or -jar
 		addJavaOptions(commands, deploymentProperties, properties);
 		addJavaExecutionOptions(commands, request);
+		// Add appProperties
+		for (String prop : appProperties.keySet()) {
+			commands.add(String.format("--%s=%s", prop, appProperties.get(prop)));
+		}
 		commands.addAll(request.getCommandlineArguments());
 		logger.debug("Java Command = " + commands);
 		return commands.toArray(new String[0]);

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -134,9 +134,10 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 				if (useDynamicPort) {
 					args.put(SERVER_PORT_KEY, String.valueOf(port));
 				}
-				ProcessBuilder builder = buildProcessBuilder(request, args, Optional.of(i)).inheritIO();
+				Map<String, String> appInstanceEnv = new HashMap<>();
+				AppInstance instance = new AppInstance(deploymentId, i, appInstanceEnv, port);
+				ProcessBuilder builder = buildProcessBuilder(request, appInstanceEnv, args, Optional.of(i)).inheritIO();
 				builder.directory(workDir.toFile());
-				AppInstance instance = new AppInstance(deploymentId, i, builder, port);
 				if (this.shouldInheritLogging(request)){
 					instance.start(builder, workDir);
 					logger.info("Deploying app with deploymentId {} instance {}.\n   Logs will be inherited.", deploymentId, i);
@@ -228,16 +229,16 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 
 		private final Map<String, String> attributes = new TreeMap<>();
 
-		private AppInstance(String deploymentId, int instanceNumber, ProcessBuilder builder, int port) throws IOException {
+		private AppInstance(String deploymentId, int instanceNumber, Map<String, String> appInstanceEnv, int port) throws IOException {
 			this.deploymentId = deploymentId;
 			this.instanceNumber = instanceNumber;
 			attributes.put("port", Integer.toString(port));
 			attributes.put("guid", Integer.toString(port));
 			this.baseUrl = new URL("http", Inet4Address.getLocalHost().getHostAddress(), port, "");
 			attributes.put("url", baseUrl.toString());
-			builder.environment().put("INSTANCE_INDEX", Integer.toString(instanceNumber));
-			builder.environment().put("SPRING_APPLICATION_INDEX", Integer.toString(instanceNumber));
-			builder.environment().put("SPRING_CLOUD_APPLICATION_GUID", Integer.toString(port));
+			appInstanceEnv.put("INSTANCE_INDEX", Integer.toString(instanceNumber));
+			appInstanceEnv.put("SPRING_APPLICATION_INDEX", Integer.toString(instanceNumber));
+			appInstanceEnv.put("SPRING_CLOUD_APPLICATION_GUID", Integer.toString(port));
 		}
 
 		@Override

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -67,7 +67,8 @@ public class LocalDeployerProperties {
 	 * Array of regular expression patterns for environment variables that
 	 * should be passed to launched applications.
 	 */
-	private String[] envVarsToInherit = {"TMP", "LANG", "LANGUAGE", "LC_.*", "PATH"};
+	private String[] envVarsToInherit = {"TMP", "LANG", "LANGUAGE", "LC_.*", "PATH",
+			"SPRING_CLOUD_APPLICATION_GUID", "SPRING_APPLICATION_INDEX", "INSTANCE_INDEX"};
 
 	/**
 	 * The command to run java.

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -67,8 +67,7 @@ public class LocalDeployerProperties {
 	 * Array of regular expression patterns for environment variables that
 	 * should be passed to launched applications.
 	 */
-	private String[] envVarsToInherit = {"TMP", "LANG", "LANGUAGE", "LC_.*", "PATH",
-			"SPRING_CLOUD_APPLICATION_GUID", "SPRING_APPLICATION_INDEX", "INSTANCE_INDEX"};
+	private String[] envVarsToInherit = {"TMP", "LANG", "LANGUAGE", "LC_.*", "PATH"};
 
 	/**
 	 * The command to run java.
@@ -85,6 +84,12 @@ public class LocalDeployerProperties {
 	 * The Java Options to pass to the JVM, e.g -Dtest=foo
 	 */
 	private String javaOpts;
+
+	/**
+	 * Flag to indicate whether application properties are passed as command line args or in a
+	 * SPRING_APPLICATION_JSON environment variable.
+	 */
+	private boolean useSpringApplicationJson = false;
 
 
 	public String getJavaCmd() {
@@ -134,6 +139,14 @@ public class LocalDeployerProperties {
 
 	public void setJavaOpts(String javaOpts) {
 		this.javaOpts = javaOpts;
+	}
+
+	public boolean isUseSpringApplicationJson() {
+		return useSpringApplicationJson;
+	}
+
+	public void setUseSpringApplicationJson(boolean useSpringApplicationJson) {
+		this.useSpringApplicationJson = useSpringApplicationJson;
 	}
 
 	private String deduceJavaCommand() {

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncher.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncher.java
@@ -109,7 +109,8 @@ public class LocalTaskLauncher extends AbstractLocalDeployerSupport implements T
 			if (useDynamicPort) {
 				args.put(SERVER_PORT_KEY, String.valueOf(port));
 			}
-			ProcessBuilder builder = buildProcessBuilder(request, args, Optional.empty());
+			Map<String, String> appInstanceEnv = new HashMap<>();
+			ProcessBuilder builder = buildProcessBuilder(request, appInstanceEnv, args, Optional.empty());
 			TaskInstance instance = new TaskInstance(builder, workDir, port);
 			running.put(taskLaunchId, instance);
 			if (getLocalDeployerProperties().isDeleteFilesOnExit()) {

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupportTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupportTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.local;
+
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the AbstractLocalDeployerSupport
+ *
+ * @author Thomas Risberg
+ */
+public class AbstractLocalDeployerSupportTests {
+
+	private Map<String, String> deploymentProperties;
+	private LocalDeployerProperties localDeployerProperties;
+	private AbstractLocalDeployerSupport localDeployerSupport;
+
+	@Before
+	public void setUp() {
+		deploymentProperties = new HashMap<>();
+		localDeployerProperties = new LocalDeployerProperties();
+		localDeployerSupport = new AbstractLocalDeployerSupport(this.localDeployerProperties) {};
+	}
+
+	@Test
+	public void testAppPropsAsCommandLineArgs() throws MalformedURLException {
+		Map<String, String> appProperties = new HashMap<>();
+		appProperties.put("test.foo", "foo");
+		appProperties.put("test.bar", "bar");
+		AppDefinition definition = new AppDefinition("randomApp", appProperties);
+		AppDeploymentRequest appDeploymentRequest =
+				new AppDeploymentRequest(definition, testResource(), deploymentProperties);
+		HashMap<String, String> envVarsToUse = new HashMap<>();
+		HashMap<String, String> appPropsToUse = new HashMap<>();
+		localDeployerSupport.handleAppPropertiesPassing(appDeploymentRequest, appProperties, envVarsToUse, appPropsToUse);
+		assertThat(appPropsToUse.size(), is(2));
+		assertThat(envVarsToUse.size(), is(0));
+		assertThat(appPropsToUse.get("test.foo"), is("foo"));
+		assertThat(appPropsToUse.get("test.bar"), is("bar"));
+	}
+
+	@Test
+	public void testSpringApplicationJson() throws MalformedURLException {
+		Map<String, String> appProperties = new HashMap<>();
+		appProperties.put("test.foo", "foo");
+		appProperties.put("test.bar", "bar");
+		AppDefinition definition = new AppDefinition("randomApp", appProperties);
+		deploymentProperties.put("spring.cloud.deployer.local.use-spring-application-json", "true");
+		AppDeploymentRequest appDeploymentRequest =
+				new AppDeploymentRequest(definition, testResource(), deploymentProperties);
+		HashMap<String, String> envVarsToUse = new HashMap<>();
+		HashMap<String, String> appPropsToUse = new HashMap<>();
+		localDeployerSupport.handleAppPropertiesPassing(appDeploymentRequest, appProperties, envVarsToUse, appPropsToUse);
+		assertThat(appPropsToUse.size(), is(0));
+		assertThat(envVarsToUse.size(), is(1));
+		assertThat(envVarsToUse.get("SPRING_APPLICATION_JSON"), is("{\"test.bar\":\"bar\",\"test.foo\":\"foo\"}"));
+	}
+
+
+	protected Resource testResource() throws MalformedURLException {
+		return new ClassPathResource("testResource.txt");
+	}
+
+}

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilderTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilderTests.java
@@ -47,7 +47,7 @@ public class DockerCommandBuilderTests {
 		Resource resource = new DockerResource("foo/bar");
 		Map<String, String> deploymentProperties = Collections.singletonMap(DockerCommandBuilder.DOCKER_CONTAINER_NAME_KEY, "gogo");
 		AppDeploymentRequest request = new AppDeploymentRequest(appDefinition, resource, deploymentProperties);
-		String[] command = commandBuilder.buildExecutionCommand(request, Collections.emptyMap(), Optional.of(1));
+		String[] command = commandBuilder.buildExecutionCommand(request, Collections.emptyMap(), Collections.emptyMap(), Optional.of(1));
 
 		assertThat(command, arrayContaining("docker", "run", "--name=gogo-1", "foo/bar"));
 	}

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,10 @@ import java.util.Map.Entry;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
@@ -50,6 +52,10 @@ import org.springframework.core.io.Resource;
 /**
  * Integration tests for {@link LocalAppDeployer}.
  *
+ * Now supports running with Docker images for tests, just set this env var:
+ *
+ *   SPRING_CLOUD_DEPLOYER_SPI_TEST_USE_DOCKER=true
+ *
  * @author Eric Bottard
  * @author Mark Fisher
  * @author Oleg Zhurakousky
@@ -61,9 +67,21 @@ public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegra
 	@Autowired
 	private AppDeployer appDeployer;
 
+	@Value("${spring-cloud-deployer-spi-test-use-docker:false}")
+	private boolean useDocker;
+
 	@Override
 	protected AppDeployer provideAppDeployer() {
 		return appDeployer;
+	}
+
+	@Override
+	protected Resource testApplication() {
+		if (useDocker) {
+			log.info("Using Docker image for tests");
+			return new DockerResource("springcloud/spring-cloud-deployer-spi-test-app:latest");
+		}
+		return super.testApplication();
 	}
 
 	@Test

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncherIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncherIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,11 @@
 
 package org.springframework.cloud.deployer.spi.local;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.deployer.spi.core.AppDefinition;
-import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.spi.local.LocalTaskLauncherIntegrationTests.Config;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.deployer.spi.test.AbstractIntegrationTests;
@@ -37,6 +32,10 @@ import org.springframework.core.io.Resource;
 /**
  * Integration tests for {@link LocalTaskLauncher}.
  *
+ * Now supports running with Docker images for tests, just set this env var:
+ *
+ *   SPRING_CLOUD_DEPLOYER_SPI_TEST_USE_DOCKER=true
+ *
  * @author Eric Bottard
  */
 @SpringBootTest(classes = {Config.class, AbstractIntegrationTests.Config.class}, value = {
@@ -46,9 +45,21 @@ public class LocalTaskLauncherIntegrationTests extends AbstractTaskLauncherInteg
 	@Autowired
 	private TaskLauncher taskLauncher;
 
+	@Value("${spring-cloud-deployer-spi-test-use-docker:false}")
+	private boolean useDocker;
+
 	@Override
 	protected TaskLauncher provideTaskLauncher() {
 		return taskLauncher;
+	}
+
+	@Override
+	protected Resource testApplication() {
+		if (useDocker) {
+			log.info("Using Docker image for tests");
+			return new DockerResource("springcloud/spring-cloud-deployer-spi-test-app:latest");
+		}
+		return super.testApplication();
 	}
 
 	@Configuration


### PR DESCRIPTION
- add switch to allow testing with docker images instead of Maven artifacts

- use SPRING_CLOUD_DEPLOYER_SPI_TEST_USE_DOCKER=true

- set instance env vars like INSTANCE_INDEX for app when deployed as docker image

- pass command line args to app when deployed as docker image

- support deploying Boot 2.0 apps by changing to pass app properties as command line args

Resolves #62
Resolves #65
Resolves #66
Resolves #67