### PR TITLE
Change random dir length on windows tests

### DIFF
--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
@@ -24,9 +24,11 @@ import static org.springframework.cloud.deployer.spi.app.DeploymentState.deploye
 import static org.springframework.cloud.deployer.spi.app.DeploymentState.unknown;
 import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
 
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.Map.Entry;
 
 import org.hamcrest.Matchers;
@@ -64,6 +66,19 @@ public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegra
 	@Override
 	protected AppDeployer provideAppDeployer() {
 		return appDeployer;
+	}
+
+	@Override
+	protected String randomName() {
+		if (LocalDeployerUtils.isWindows()) {
+			// tweak random dir name on win to be shorter
+			String uuid = UUID.randomUUID().toString();
+			long l = ByteBuffer.wrap(uuid.toString().getBytes()).getLong();
+			return name.getMethodName() + Long.toString(l, Character.MAX_RADIX);
+		}
+		else {
+			return super.randomName();
+		}
 	}
 
 	@Test

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncherIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncherIntegrationTests.java
@@ -16,8 +16,10 @@
 
 package org.springframework.cloud.deployer.spi.local;
 
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -49,6 +51,19 @@ public class LocalTaskLauncherIntegrationTests extends AbstractTaskLauncherInteg
 	@Override
 	protected TaskLauncher provideTaskLauncher() {
 		return taskLauncher;
+	}
+
+	@Override
+	protected String randomName() {
+		if (LocalDeployerUtils.isWindows()) {
+			// tweak random dir name on win to be shorter
+			String uuid = UUID.randomUUID().toString();
+			long l = ByteBuffer.wrap(uuid.toString().getBytes()).getLong();
+			return name.getMethodName() + Long.toString(l, Character.MAX_RADIX);
+		}
+		else {
+			return super.randomName();
+		}
 	}
 
 	@Configuration


### PR DESCRIPTION
NOTE: I ran CI build against my own branch with these changes and build was green.

- Created directory path is too long due to
  use of multiple UUID's causing ProcessBuilder
  failure on windows. Change random name to be
  shorter on windows using less reliable
  shorter UUID.

Fixes #70
Fixes spring-cloud/spring-cloud-dataflow#1586