### PR TITLE
Fixed SAJ not being used by local and docker deployers

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -191,6 +191,7 @@ public abstract class AbstractLocalDeployerSupport {
 		ProcessBuilder builder = new ProcessBuilder(commands);
 		if (!(request.getResource() instanceof DockerResource)) {
 			builder.environment().putAll(appInstanceEnv);
+			builder.environment().putAll(appInstanceEnvToUse);
 		}
 		retainEnvVars(builder.environment().keySet());
 		

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -83,7 +83,7 @@ public class LocalDeployerProperties {
 	 * Array of regular expression patterns for environment variables that
 	 * should be passed to launched applications.
 	 */
-	private String[] envVarsToInherit = {"TMP", "LANG", "LANGUAGE", "LC_.*", "PATH"};
+	private String[] envVarsToInherit = {"TMP", "LANG", "LANGUAGE", "LC_.*", "PATH", "SPRING_APPLICATION_JSON"};
 
 	/**
 	 * The command to run java.

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilderTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilderTests.java
@@ -17,14 +17,14 @@
 package org.springframework.cloud.deployer.spi.local;
 
 import static org.hamcrest.collection.IsArrayContainingInOrder.arrayContaining;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.hamcrest.collection.IsArrayContainingInOrder;
 import org.junit.Test;
 
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
@@ -50,6 +50,25 @@ public class DockerCommandBuilderTests {
 		String[] command = commandBuilder.buildExecutionCommand(request, Collections.emptyMap(), Collections.emptyMap(), Optional.of(1));
 
 		assertThat(command, arrayContaining("docker", "run", "--name=gogo-1", "foo/bar"));
+	}
+
+	@Test
+	public void testSpringApplicationJSON() throws Exception {
+		LocalDeployerProperties properties = new LocalDeployerProperties();
+		properties.setUseSpringApplicationJson(true);
+		LocalAppDeployer deployer = new LocalAppDeployer(properties);
+		AppDefinition definition = new AppDefinition("foo", Collections.singletonMap("foo","bar"));
+		Resource resource = new DockerResource("foo/bar");
+		Map<String, String> deploymentProperties = new HashMap<>();
+		deploymentProperties.put(LocalDeployerProperties.DEBUG_PORT, "9999");
+		deploymentProperties.put(LocalDeployerProperties.DEBUG_SUSPEND, "y");
+		deploymentProperties.put(LocalDeployerProperties.INHERIT_LOGGING, "true");
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, deploymentProperties);
+
+
+		ProcessBuilder builder = deployer.buildProcessBuilder(request, Collections.emptyMap(), request.getDefinition().getProperties(), Optional.of(1), "foo" );
+		assertThat(builder.command(), hasItems("-e", "SPRING_APPLICATION_JSON={\"foo\":\"bar\"}"));
+
 	}
 
 }

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/JavaExecutionCommandBuilderTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/JavaExecutionCommandBuilderTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.deployer.spi.local;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
@@ -27,15 +28,18 @@ import org.springframework.core.io.UrlResource;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.springframework.cloud.deployer.spi.local.LocalDeployerProperties.PREFIX;
 
@@ -163,6 +167,26 @@ public class JavaExecutionCommandBuilderTests {
                 new AppDeploymentRequest(definition, testResource(), deploymentProperties);
         commandBuilder.addJavaExecutionOptions(args, appDeploymentRequest);
     }
+
+    @Test
+    public void testCommandBuilderSpringApplicationJson() throws Exception {
+        String mainJar = "/tmp/myapp.jar";
+        LocalDeployerProperties properties = new LocalDeployerProperties();
+        properties.setUseSpringApplicationJson(true);
+        LocalAppDeployer deployer = new LocalAppDeployer(properties);
+        AppDefinition definition = new AppDefinition("foo", Collections.singletonMap("foo","bar"));
+
+        Map<String, String> deploymentProperties = new HashMap<>();
+        deploymentProperties.put(LocalDeployerProperties.DEBUG_PORT, "9999");
+        deploymentProperties.put(LocalDeployerProperties.DEBUG_SUSPEND, "y");
+        deploymentProperties.put(LocalDeployerProperties.INHERIT_LOGGING, "true");
+        AppDeploymentRequest request = new AppDeploymentRequest(definition, testResource(), deploymentProperties);
+
+
+        ProcessBuilder builder = deployer.buildProcessBuilder(request, Collections.emptyMap(), request.getDefinition().getProperties(), Optional.of(1), "foo" );
+        assertThat(builder.environment().keySet(), hasItem("SPRING_APPLICATION_JSON"));
+    }
+
 
 
 


### PR DESCRIPTION
 Fixes #88
 - SAJ was not being used at all for the deployers, fixed missing
   environment variable copy
 - Added a couple of tests to test the ProcessBuilder itself