### PR TITLE
Set SPRING_APPLICATION_JSON as default

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -226,8 +226,6 @@ public abstract class AbstractLocalDeployerSupport {
 				}
 				appInstanceEnvToUse.putAll(Collections.singletonMap(
 						SPRING_APPLICATION_JSON, OBJECT_MAPPER.writeValueAsString(localApplicationProperties)));
-			} catch (JsonProcessingException e) {
-				throw new RuntimeException(e);
 			}
 			catch (IOException e) {
 				throw new RuntimeException(e);

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.deployer.spi.local;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +30,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,11 +52,14 @@ import org.springframework.web.client.RestTemplate;
  * @author Ilayaperumal Gopinathan
  * @author Thomas Risberg
  * @author Oleg Zhurakousky
+ * @author Vinicius Carvalho
  */
 public abstract class AbstractLocalDeployerSupport {
 
 	public static final String USE_SPRING_APPLICATION_JSON_KEY =
 			LocalDeployerProperties.PREFIX + ".use-spring-application-json";
+
+	public static final String SPRING_APPLICATION_JSON = "SPRING_APPLICATION_JSON";
 
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -213,9 +218,18 @@ public abstract class AbstractLocalDeployerSupport {
 											  Map<String, String> appPropertiesToUse) {
 		if (useSpringApplicationJson(request)) {
 			try {
+				//If SPRING_APPLICATION_JSON is found, explode it and merge back into appProperties
+				Map<String, String> localApplicationProperties = new HashMap<>(appProperties);
+				if(localApplicationProperties.containsKey(SPRING_APPLICATION_JSON)){
+					localApplicationProperties.putAll(OBJECT_MAPPER.readValue(appProperties.get(SPRING_APPLICATION_JSON), new TypeReference<HashMap<String,Object>>() {}));
+					localApplicationProperties.remove(SPRING_APPLICATION_JSON);
+				}
 				appInstanceEnvToUse.putAll(Collections.singletonMap(
-						"SPRING_APPLICATION_JSON", OBJECT_MAPPER.writeValueAsString(appProperties)));
+						SPRING_APPLICATION_JSON, OBJECT_MAPPER.writeValueAsString(localApplicationProperties)));
 			} catch (JsonProcessingException e) {
+				throw new RuntimeException(e);
+			}
+			catch (IOException e) {
 				throw new RuntimeException(e);
 			}
 		}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @author Ilayaperumal Gopinathan
  * @author Oleg Zhurakousky
+ * @author Vinicius Carvalho
  */
 @ConfigurationProperties(prefix = LocalDeployerProperties.PREFIX)
 public class LocalDeployerProperties {
@@ -106,7 +107,7 @@ public class LocalDeployerProperties {
 	 * Flag to indicate whether application properties are passed as command line args or in a
 	 * SPRING_APPLICATION_JSON environment variable.
 	 */
-	private boolean useSpringApplicationJson = false;
+	private boolean useSpringApplicationJson = true;
 
 	/**
 	 * The target percentag of free disk space to always aim for when cleaning downloaded

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/JavaExecutionCommandBuilderTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/JavaExecutionCommandBuilderTests.java
@@ -168,7 +168,6 @@ public class JavaExecutionCommandBuilderTests {
     public void testCommandBuilderSpringApplicationJson() throws Exception {
         String mainJar = "/tmp/myapp.jar";
         LocalDeployerProperties properties = new LocalDeployerProperties();
-        properties.setUseSpringApplicationJson(true);
         LocalAppDeployer deployer = new LocalAppDeployer(properties);
         AppDefinition definition = new AppDefinition("foo", Collections.singletonMap("foo","bar"));
 
@@ -181,6 +180,28 @@ public class JavaExecutionCommandBuilderTests {
         ProcessBuilder builder = deployer.buildProcessBuilder(request, Collections.emptyMap(), request.getDefinition().getProperties(), Optional.of(1), "foo" );
         assertThat(builder.environment().keySet(), hasItem("SPRING_APPLICATION_JSON"));
         assertThat(builder.environment().get("SPRING_APPLICATION_JSON"), is("{\"foo\":\"bar\"}"));
+    }
+    @Test
+    public void testCommandBuilderWithSpringApplicationJson() throws Exception {
+        String mainJar = "/tmp/myapp.jar";
+        LocalDeployerProperties properties = new LocalDeployerProperties();
+        LocalAppDeployer deployer = new LocalAppDeployer(properties);
+        Map<String,String> applicationProperties = new HashMap<>();
+        applicationProperties.put("foo","bar");
+        String SAJ = "{\"debug\":\"true\"}";
+        applicationProperties.put("SPRING_APPLICATION_JSON",SAJ);
+        AppDefinition definition = new AppDefinition("foo", applicationProperties);
+
+        deploymentProperties.put(LocalDeployerProperties.DEBUG_PORT, "9999");
+        deploymentProperties.put(LocalDeployerProperties.DEBUG_SUSPEND, "y");
+        deploymentProperties.put(LocalDeployerProperties.INHERIT_LOGGING, "true");
+        AppDeploymentRequest request = new AppDeploymentRequest(definition, testResource(), deploymentProperties);
+
+
+        ProcessBuilder builder = deployer.buildProcessBuilder(request, Collections.emptyMap(), request.getDefinition().getProperties(), Optional.of(1), "foo" );
+        assertThat(builder.environment().keySet(), hasItem("SPRING_APPLICATION_JSON"));
+        assertThat(builder.environment().get("SPRING_APPLICATION_JSON"), is("{\"foo\":\"bar\",\"debug\":\"true\"}"));
+
     }
 
 


### PR DESCRIPTION
Fixes #91
- SPRING_APPLICATION_JSON is now default way to pass properties
- If present as application properties, we merge it