### PR TITLE
Refactor server port calculation

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -66,8 +66,6 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 
 	private static final Logger logger = LoggerFactory.getLogger(LocalAppDeployer.class);
 
-	static final String SERVER_PORT_KEY = "server.port";
-
 	private static final String JMX_DEFAULT_DOMAIN_KEY = "spring.jmx.default-domain";
 
 	private static final String ENDPOINTS_SHUTDOWN_ENABLED_KEY = "endpoints.shutdown.enabled";

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncher.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncher.java
@@ -57,10 +57,6 @@ public class LocalTaskLauncher extends AbstractLocalDeployerSupport implements T
 
 	private static final Logger logger = LoggerFactory.getLogger(LocalTaskLauncher.class);
 
-	private static final String SERVER_PORT_KEY = "server.port";
-
-	private final String SERVER_PORT_KEY_PREFIX = "--" + SERVER_PORT_KEY + "=";
-
 	private static final String JMX_DEFAULT_DOMAIN_KEY = "spring.jmx.default-domain";
 
 	private final Map<String, TaskInstance> running = new ConcurrentHashMap<>();
@@ -116,7 +112,7 @@ public class LocalTaskLauncher extends AbstractLocalDeployerSupport implements T
 	}
 
 	private boolean isDynamicPort(AppDeploymentRequest request) {
-		boolean isServerPortKeyonArgs = isServerPortKeyPresentOnArgs(request);
+		boolean isServerPortKeyonArgs = isServerPortKeyPresentOnArgs(request) != null;
 		return !request.getDefinition().getProperties().containsKey(SERVER_PORT_KEY)
 				&& !isServerPortKeyonArgs;
 	}
@@ -282,14 +278,4 @@ public class LocalTaskLauncher extends AbstractLocalDeployerSupport implements T
 		}
 	}
 
-	private boolean isServerPortKeyPresentOnArgs(AppDeploymentRequest request) {
-		boolean result = false;
-			for (String argument : request.getCommandlineArguments()) {
-				if (argument.startsWith(SERVER_PORT_KEY_PREFIX)) {
-					result = true;
-					break;
-				}
-		}
-		return result;
-	}
 }

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncherIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncherIntegrationTests.java
@@ -17,20 +17,34 @@
 package org.springframework.cloud.deployer.spi.local;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.local.LocalTaskLauncherIntegrationTests.Config;
+import org.springframework.cloud.deployer.spi.task.LaunchState;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.deployer.spi.test.AbstractIntegrationTests;
 import org.springframework.cloud.deployer.spi.test.AbstractTaskLauncherIntegrationTests;
+import org.springframework.cloud.deployer.spi.test.EventuallyMatcher;
+import org.springframework.cloud.deployer.spi.test.Timeout;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
+import org.springframework.util.SocketUtils;
 
 /**
  * Integration tests for {@link LocalTaskLauncher}.
@@ -78,6 +92,31 @@ public class LocalTaskLauncherIntegrationTests extends AbstractTaskLauncherInteg
 		else {
 			return super.randomName();
 		}
+	}
+
+	@Test
+	public void testPassingServerPortViaCommandLineArgs() throws InterruptedException {
+		Map<String, String> appProperties = new HashMap();
+		appProperties.put("killDelay", "0");
+		appProperties.put("exitCode", "0");
+
+		AppDefinition definition = new AppDefinition(this.randomName(), appProperties);
+
+		Resource resource = this.testApplication();
+
+		List<String> commandLineArgs = new ArrayList<>(1);
+		commandLineArgs.add(LocalTaskLauncher.SERVER_PORT_KEY_PREFIX + SocketUtils.findAvailableTcpPort(LocalTaskLauncher.DEFAULT_SERVER_PORT));
+
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, null, commandLineArgs);
+
+		this.log.info("Launching {}...", request.getDefinition().getName());
+
+		String launchId = this.taskLauncher().launch(request);
+		Timeout timeout = this.deploymentTimeout();
+
+		Assert.assertThat(launchId, EventuallyMatcher.eventually(this.hasStatusThat(Matchers.hasProperty("state", Matchers.is(LaunchState.complete))), timeout.maxAttempts, timeout.pause));
+
+		this.taskLauncher().destroy(definition.getName());
 	}
 
 	@Configuration


### PR DESCRIPTION
This commit changes the way the server port calculation is performed.
In order of precidence, it will calculate a dynamic port if required,
otherwise it will obtain the server port from the command line args,
otherwise it will obtain the server port from the application
properties, and if none of those options are valid 8080 will be
returned.

Resolves spring-cloud/spring-cloud-deployer-local#106