### PR TITLE
Fix property handling with SAJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>1.3.1.RELEASE</version>
+		<version>1.3.2.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
 	<properties>
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring-cloud-deployer.version>1.3.1.RELEASE</spring-cloud-deployer.version>
+		<spring-cloud-deployer.version>1.3.2.BUILD-SNAPSHOT</spring-cloud-deployer.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -321,7 +321,7 @@ public abstract class AbstractLocalDeployerSupport {
 		return Integer.parseInt(basePort) + instanceIndex;
 	}
 
-	private boolean useSpringApplicationJson(AppDeploymentRequest request) {
+	protected boolean useSpringApplicationJson(AppDeploymentRequest request) {
 		return request.getDefinition().getProperties().containsKey(USE_SPRING_APPLICATION_JSON_KEY) || this.properties.isUseSpringApplicationJson();
 	}
 

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -74,9 +74,6 @@ public abstract class AbstractLocalDeployerSupport {
 
 	public static final int DEFAULT_SERVER_PORT = 8080;
 
-	private String[] envVarsSetByDeployer =
-			{"SPRING_CLOUD_APPLICATION_GUID", "SPRING_APPLICATION_INDEX", "INSTANCE_INDEX"};
-
 	/**
 	 * Instantiates a new abstract deployer support.
 	 *

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -171,19 +171,15 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 
 				int port = calcServerPort(request, useDynamicPort, appInstanceEnv);
 
-				appInstanceEnv.put("INSTANCE_INDEX", Integer.toString(i));
-				appInstanceEnv.put("SPRING_APPLICATION_INDEX", Integer.toString(i));
-				appInstanceEnv.put("SPRING_CLOUD_APPLICATION_GUID", Integer.toString(port));
-
-				// we only set 'normal' style props reflecting what we set for env format
-				// for cross reference to work inside SAJ.
-				// looks like for now we can't remove these env style formats as i.e.
-				// DeployerIntegrationTestProperties in tests really assume 'INSTANCE_INDEX' and
-				// this might be indication that we can't yet fully remove those.
 				if (useSpringApplicationJson(request)) {
 					appInstanceEnv.put("instance.index", Integer.toString(i));
 					appInstanceEnv.put("spring.application.index", Integer.toString(i));
 					appInstanceEnv.put("spring.cloud.application.guid", Integer.toString(port));
+				}
+				else {
+					appInstanceEnv.put("INSTANCE_INDEX", Integer.toString(i));
+					appInstanceEnv.put("SPRING_APPLICATION_INDEX", Integer.toString(i));
+					appInstanceEnv.put("SPRING_CLOUD_APPLICATION_GUID", Integer.toString(port));
 				}
 
 				AppInstance instance = new AppInstance(deploymentId, i, port);

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -175,6 +175,17 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 				appInstanceEnv.put("SPRING_APPLICATION_INDEX", Integer.toString(i));
 				appInstanceEnv.put("SPRING_CLOUD_APPLICATION_GUID", Integer.toString(port));
 
+				// we only set 'normal' style props reflecting what we set for env format
+				// for cross reference to work inside SAJ.
+				// looks like for now we can't remove these env style formats as i.e.
+				// DeployerIntegrationTestProperties in tests really assume 'INSTANCE_INDEX' and
+				// this might be indication that we can't yet fully remove those.
+				if (useSpringApplicationJson(request)) {
+					appInstanceEnv.put("instance.index", Integer.toString(i));
+					appInstanceEnv.put("spring.application.index", Integer.toString(i));
+					appInstanceEnv.put("spring.cloud.application.guid", Integer.toString(port));
+				}
+
 				AppInstance instance = new AppInstance(deploymentId, i, port);
 
 				ProcessBuilder builder = buildProcessBuilder(request, appInstanceEnv, Optional.of(i), deploymentId)

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerEnvironmentIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerEnvironmentIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
-import org.springframework.cloud.deployer.spi.local.LocalAppDeployerIntegrationTests.Config;
+import org.springframework.cloud.deployer.spi.local.LocalAppDeployerEnvironmentIntegrationTests.Config;
 import org.springframework.cloud.deployer.spi.test.AbstractAppDeployerIntegrationTests;
 import org.springframework.cloud.deployer.spi.test.AbstractIntegrationTests;
 import org.springframework.cloud.deployer.spi.test.Timeout;
@@ -61,7 +61,7 @@ import static org.springframework.cloud.deployer.spi.app.DeploymentState.unknown
 import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
 
 /**
- * Integration tests for {@link LocalAppDeployer}.
+ * Integration tests for {@link LocalAppDeployer} not using SAJ.
  *
  * Now supports running with Docker images for tests, just set this env var:
  *
@@ -73,9 +73,10 @@ import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.even
  * @author Janne Valkealahti
  * @author Ilayaperumal Gopinathan
  */
-@SpringBootTest(classes = {Config.class, AbstractIntegrationTests.Config.class}, value = {
-		"maven.remoteRepositories.springRepo.url=https://repo.spring.io/libs-snapshot" })
-public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegrationTests {
+@SpringBootTest(classes = { Config.class, AbstractIntegrationTests.Config.class }, value = {
+		"maven.remoteRepositories.springRepo.url=https://repo.spring.io/libs-snapshot",
+		"spring.cloud.deployer.local.use-spring-application-json=false" })
+public class LocalAppDeployerEnvironmentIntegrationTests extends AbstractAppDeployerIntegrationTests {
 
 	private static final String TESTAPP_DOCKER_IMAGE_NAME = "springcloud/spring-cloud-deployer-spi-test-app:latest";
 
@@ -113,7 +114,7 @@ public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegra
 	}
 
 	@Test
-	public void testEnvVariablesInheritedViaEnvEndpoint() {
+	public void testEnvVariablesInheritedViaEnvEndpointNoSaj() {
 		if (useDocker) {
 			// would not expect to be able to check anything on docker
 			return;
@@ -156,11 +157,11 @@ public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegra
 		}
 		else {
 			assertThat(env, containsString("\"PATH\""));
-			// we're defaulting to SAJ so it's i.e.
-			// instance.index not INSTANCE_INDEX
-			assertThat(env, containsString("\"instance.index\""));
-			assertThat(env, containsString("\"spring.application.index\""));
-			assertThat(env, containsString("\"spring.cloud.application.guid\""));
+			// we're not using SAJ so it's i.e.
+			// INSTANCE_INDEX not instance.index
+			assertThat(env, containsString("\"INSTANCE_INDEX\""));
+			assertThat(env, containsString("\"SPRING_APPLICATION_INDEX\""));
+			assertThat(env, containsString("\"SPRING_CLOUD_APPLICATION_GUID\""));
 		}
 	}
 


### PR DESCRIPTION
- Now as a quick workaround to get metrics working,
  conditionally add normal properties reflecting i.e.
  SPRING_CLOUD_APPLICATION_GUID as spring.cloud.application.guid.
- See from added comments in code why it wasn't possible to
  remove those env style formats.
- This change now allows scdf server to show metrics again.
- Fixes #109