### PR TITLE
Force INSTANCE_INDEX with SAJ

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -173,8 +173,7 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 
 				if (useSpringApplicationJson(request)) {
 					appInstanceEnv.put("instance.index", Integer.toString(i));
-					// need to force env format of index as it's required by streams
-					appInstanceEnv.put("INSTANCE_INDEX", Integer.toString(i));
+					appInstanceEnv.put("spring.cloud.stream.instanceIndex", Integer.toString(i));
 					appInstanceEnv.put("spring.application.index", Integer.toString(i));
 					appInstanceEnv.put("spring.cloud.application.guid", Integer.toString(port));
 				}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -173,6 +173,8 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 
 				if (useSpringApplicationJson(request)) {
 					appInstanceEnv.put("instance.index", Integer.toString(i));
+					// need to force env format of index as it's required by streams
+					appInstanceEnv.put("INSTANCE_INDEX", Integer.toString(i));
 					appInstanceEnv.put("spring.application.index", Integer.toString(i));
 					appInstanceEnv.put("spring.cloud.application.guid", Integer.toString(port));
 				}

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
@@ -161,6 +161,7 @@ public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegra
 			assertThat(env, containsString("\"instance.index\""));
 			assertThat(env, containsString("\"spring.application.index\""));
 			assertThat(env, containsString("\"spring.cloud.application.guid\""));
+			assertThat(env, containsString("\"INSTANCE_INDEX\""));
 		}
 	}
 

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
@@ -161,7 +161,7 @@ public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegra
 			assertThat(env, containsString("\"instance.index\""));
 			assertThat(env, containsString("\"spring.application.index\""));
 			assertThat(env, containsString("\"spring.cloud.application.guid\""));
-			assertThat(env, containsString("\"INSTANCE_INDEX\""));
+			assertThat(env, containsString("\"spring.cloud.stream.instanceIndex\""));
 		}
 	}
 


### PR DESCRIPTION
- For partitioning to work we need to force
  env format as INSTANCE_INDEX into SAJ because
  spring cloud stream uses
  @Value("${INSTANCE_INDEX:${CF_INSTANCE_INDEX:0}}")
- Fixes #114 
- Resolves spring-cloud/spring-cloud-dataflow#2164