### PR TITLE
Support zero port

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -306,10 +306,12 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 		private File workFile;
 		private File stdout;
 		private File stderr;
+		private int port;
 
 		private AppInstance(String deploymentId, int instanceNumber, int port) throws IOException {
 			this.deploymentId = deploymentId;
 			this.instanceNumber = instanceNumber;
+			this.port = port;
 			attributes.put("port", Integer.toString(port));
 			attributes.put("guid", Integer.toString(port));
 			this.baseUrl = new URL("http", Inet4Address.getLocalHost().getHostAddress(), port, "");
@@ -342,6 +344,12 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 			// TODO: consider using exit code mapper concept from batch
 			if (exit != null) {
 				return DeploymentState.failed;
+			}
+			if (port < 1) {
+				// Support case where user passed in zero or negative port indicating fully random
+				// chosen by OS. In this case we simply return deployed if process is up.
+				// Also we can't even try http check as we would not know port to connect to.
+				return DeploymentState.deployed;
 			}
 			try {
 				HttpURLConnection urlConnection = (HttpURLConnection) baseUrl.openConnection();

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
@@ -239,6 +239,30 @@ public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegra
 		deployer.undeploy(deploymentId);
 	}
 
+
+	@Test
+	public void testZeroPortReportsDeployed() {
+		Map<String, String> properties = new HashMap<>();
+		properties.put("server.port", "0");
+		AppDefinition definition = new AppDefinition(randomName(), properties);
+		Resource resource = testApplication();
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource);
+
+		log.info("Deploying {}...", request.getDefinition().getName());
+
+		String deploymentId = appDeployer().deploy(request);
+		Timeout timeout = deploymentTimeout();
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
+
+		log.info("Undeploying {}...", deploymentId);
+
+		timeout = undeploymentTimeout();
+		appDeployer().undeploy(deploymentId);
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.<AppStatus>hasProperty("state", is(unknown))), timeout.maxAttempts, timeout.pause));
+	}
+
 	private String getCommandOutput(String cmd) throws IOException {
 		Process process = Runtime.getRuntime().exec(cmd);
 		BufferedReader stdInput = new BufferedReader(new InputStreamReader(process.getInputStream()));


### PR DESCRIPTION
- Now simply handling case where we don't have
  a known port by returning `deployed` if process
  is alive. With fully random port, deployer fully
  fail to understand anything about trying to open
  http connection.
- This is best we can do for now as it's usually
  convenient to use zero ports.
- Fixes #122