### PR TITLE
Prune task instance history map

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -183,6 +183,17 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 					appInstanceEnv.put("SPRING_CLOUD_APPLICATION_GUID", Integer.toString(port));
 				}
 
+				// we only set 'normal' style props reflecting what we set for env format
+				// for cross reference to work inside SAJ.
+				// looks like for now we can't remove these env style formats as i.e.
+				// DeployerIntegrationTestProperties in tests really assume 'INSTANCE_INDEX' and
+				// this might be indication that we can't yet fully remove those.
+				if (useSpringApplicationJson(request)) {
+					appInstanceEnv.put("instance.index", Integer.toString(i));
+					appInstanceEnv.put("spring.application.index", Integer.toString(i));
+					appInstanceEnv.put("spring.cloud.application.guid", Integer.toString(port));
+				}
+
 				AppInstance instance = new AppInstance(deploymentId, i, port);
 
 				ProcessBuilder builder = buildProcessBuilder(request, appInstanceEnv, Optional.of(i), deploymentId)


### PR DESCRIPTION
This solution aim to clean the history of repeatedly executed tasks. Only the last launched Task instance is kept in the running map.
- Track the previous task-launch instance for the any given Task (identified by the Task Name)
- On new Task launch event, find all previous task instances for the Task being launched.
- Found instances in non-running and non-launching state are removed from the running and the tracking maps.

Resolves #112