### PR TITLE
Configurable random port range

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -399,7 +398,7 @@ public abstract class AbstractLocalDeployerSupport {
 		Set<Integer> availPorts = new HashSet<>();
 		// SocketUtils.findAvailableTcpPorts retries 6 times, add additional retry on top.
 		for (int retryCount = 0; retryCount < 5; retryCount++) {
-			int randomInt = ThreadLocalRandom.current().nextInt(properties.getPortBound().getLower(), properties.getPortBound().getUpper());
+			int randomInt = ThreadLocalRandom.current().nextInt(properties.getPortRange().getLow(), properties.getPortRange().getHigh());
 			try {
 				availPorts = SocketUtils.findAvailableTcpPorts(5, randomInt, randomInt + 5);
 				try {
@@ -416,7 +415,7 @@ public abstract class AbstractLocalDeployerSupport {
 			}
 		}
 		if (availPorts.isEmpty()) {
-			throw new IllegalStateException("Could not find an available TCP port in the range" + properties.getPortBound());
+			throw new IllegalStateException("Could not find an available TCP port in the range" + properties.getPortRange());
 		}
 
 		int finalPort = -1;
@@ -429,7 +428,7 @@ public abstract class AbstractLocalDeployerSupport {
 			}
 		}
 		if (finalPort == -1) {
-			throw new IllegalStateException("Could not find a free random port range " + properties.getPortBound());
+			throw new IllegalStateException("Could not find a free random port range " + properties.getPortRange());
 		}
 		logger.debug("Using Port: " + finalPort);
 		return finalPort;

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -122,6 +122,45 @@ public class LocalDeployerProperties {
 	 */
 	private boolean useSpringApplicationJson = true;
 
+	private PortBound portBound = new PortBound();
+
+	public static class PortBound {
+
+		/**
+		 * Lower bound for computing applications's random port.
+		 */
+		private int lower = 20000;
+
+		/**
+		 * Lower bound for computing applications's random port.
+		 */
+		private int upper = 61000;
+
+		public int getLower() {
+			return lower;
+		}
+
+		public void setLower(int lower) {
+			this.lower = lower;
+		}
+
+		public int getUpper() {
+			return upper;
+		}
+
+		public void setUpper(int upper) {
+			this.upper = upper;
+		}
+
+		@Override
+		public String toString() {
+			return "{" +
+					"lower=" + lower +
+					", upper=" + upper +
+					'}';
+		}
+	}
+
 	public String getJavaCmd() {
 		return javaCmd;
 	}
@@ -179,6 +218,10 @@ public class LocalDeployerProperties {
 		this.useSpringApplicationJson = useSpringApplicationJson;
 	}
 
+	public PortBound getPortBound() {
+		return portBound;
+	}
+
 	private String deduceJavaCommand() {
 		String javaExecutablePath = JAVA_COMMAND;
 		String javaHome = System.getProperty("java.home");
@@ -198,7 +241,7 @@ public class LocalDeployerProperties {
 	}
 
 	@Override
-	public String toString(){
+	public String toString() {
 		return new ToStringCreator(this)
 				.append("workingDirectoriesRoot", this.workingDirectoriesRoot)
 				.append("javaOpts", this.javaOpts)

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.deployer.spi.local;
 import java.io.File;
 import java.nio.file.Path;
 
-import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 import org.slf4j.Logger;
@@ -122,42 +121,39 @@ public class LocalDeployerProperties {
 	 */
 	private boolean useSpringApplicationJson = true;
 
-	private PortBound portBound = new PortBound();
+	private PortRange portRange = new PortRange();
 
-	public static class PortBound {
-
-		/**
-		 * Lower bound for computing applications's random port.
-		 */
-		private int lower = 20000;
+	public static class PortRange {
 
 		/**
 		 * Lower bound for computing applications's random port.
 		 */
-		private int upper = 61000;
+		private int low = 20000;
 
-		public int getLower() {
-			return lower;
+		/**
+		 * Upper bound for computing applications's random port.
+		 */
+		private int high = 61000;
+
+		public int getLow() {
+			return low;
 		}
 
-		public void setLower(int lower) {
-			this.lower = lower;
+		public void setLow(int low) {
+			this.low = low;
 		}
 
-		public int getUpper() {
-			return upper;
+		public int getHigh() {
+			return high;
 		}
 
-		public void setUpper(int upper) {
-			this.upper = upper;
+		public void setHigh(int high) {
+			this.high = high;
 		}
 
 		@Override
 		public String toString() {
-			return "{" +
-					"lower=" + lower +
-					", upper=" + upper +
-					'}';
+			return "{ low=" + low + ", high=" + high + '}';
 		}
 	}
 
@@ -218,8 +214,8 @@ public class LocalDeployerProperties {
 		this.useSpringApplicationJson = useSpringApplicationJson;
 	}
 
-	public PortBound getPortBound() {
-		return portBound;
+	public PortRange getPortRange() {
+		return portRange;
 	}
 
 	private String deduceJavaCommand() {

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/BoundedRandomPortTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/BoundedRandomPortTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.local;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Tzolov
+ */
+public class BoundedRandomPortTests {
+
+	private AbstractLocalDeployerSupport localDeployerSupport;
+
+	@Before
+	public void setUp() {
+		LocalDeployerProperties properties = new LocalDeployerProperties();
+		properties.getPortBound().setLower(30001);
+		properties.getPortBound().setUpper(30213);
+		localDeployerSupport = new AbstractLocalDeployerSupport(properties) {};
+	}
+
+	@Test
+	public void portTests() {
+		//No exception should be thrown
+		for (int i = 0; i < 30; i++) {
+			System.out.println(i);
+			int port = localDeployerSupport.getRandomPort();
+			assertThat(port, Matchers.greaterThanOrEqualTo(30001));
+			assertThat(port, Matchers.lessThanOrEqualTo(30213 + 5));
+		}
+	}
+}

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/RandomPortRangeContextTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/RandomPortRangeContextTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.local;
+
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Christian Tzolov
+ */
+public class RandomPortRangeContextTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(LocalDeployerAutoConfiguration.class));
+
+	@Test
+	public void defaultProtRangeProperties() {
+		this.contextRunner
+				.withUserConfiguration(LocalDeployerAutoConfiguration.class)
+				.run((context) -> {
+					assertThat(context).hasSingleBean(LocalDeployerProperties.class);
+					assertThat(context).hasSingleBean(LocalDeployerAutoConfiguration.class);
+					assertThat(context).getBean(LocalDeployerProperties.class)
+							.hasFieldOrPropertyWithValue("portRange.low", 20000);
+					assertThat(context).getBean(LocalDeployerProperties.class)
+							.hasFieldOrPropertyWithValue("portRange.high", 61000);
+				});
+	}
+
+	@Test
+	public void presetProtRangeProperties() {
+		this.contextRunner
+				.withUserConfiguration(LocalDeployerAutoConfiguration.class)
+				.withPropertyValues("spring.cloud.deployer.local.portRange.low=20001", "spring.cloud.deployer.local.portRange.high=20003")
+				.run((context) -> {
+					assertThat(context).hasSingleBean(LocalDeployerProperties.class);
+					assertThat(context).hasSingleBean(LocalDeployerAutoConfiguration.class);
+					assertThat(context).getBean(LocalDeployerProperties.class)
+							.hasFieldOrPropertyWithValue("portRange.low", 20001);
+					assertThat(context).getBean(LocalDeployerProperties.class)
+							.hasFieldOrPropertyWithValue("portRange.high", 20003);
+				});
+	}
+}

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/RandomPortRangeTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/RandomPortRangeTests.java
@@ -24,21 +24,20 @@ import static org.junit.Assert.assertThat;
 /**
  * @author Christian Tzolov
  */
-public class BoundedRandomPortTests {
+public class RandomPortRangeTests {
 
 	private AbstractLocalDeployerSupport localDeployerSupport;
 
 	@Before
 	public void setUp() {
 		LocalDeployerProperties properties = new LocalDeployerProperties();
-		properties.getPortBound().setLower(30001);
-		properties.getPortBound().setUpper(30213);
+		properties.getPortRange().setLow(30001);
+		properties.getPortRange().setHigh(30213);
 		localDeployerSupport = new AbstractLocalDeployerSupport(properties) {};
 	}
 
 	@Test
 	public void portTests() {
-		//No exception should be thrown
 		for (int i = 0; i < 30; i++) {
 			System.out.println(i);
 			int port = localDeployerSupport.getRandomPort();

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/RandomPortRangeTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/RandomPortRangeTests.java
@@ -39,7 +39,6 @@ public class RandomPortRangeTests {
 	@Test
 	public void portTests() {
 		for (int i = 0; i < 30; i++) {
-			System.out.println(i);
 			int port = localDeployerSupport.getRandomPort();
 			assertThat(port, Matchers.greaterThanOrEqualTo(30001));
 			assertThat(port, Matchers.lessThanOrEqualTo(30213 + 5));


### PR DESCRIPTION
  - Add spring.cloud.deployer.local.portBound.lower and spring.cloud.deployer.local.portBound.upper property to configure the range of the generated random properties.
  - lower defaults to 20000 and upper to 61000 (e.g. the previous fixed values).
  - The random port is generated in the range [lower, upper + 5]

  Resolves #133