### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/JavaExecutionCommandBuilderTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/JavaExecutionCommandBuilderTests.java
@@ -134,7 +134,7 @@ public class JavaExecutionCommandBuilderTests {
         AppDefinition definition = new AppDefinition("randomApp", new HashMap<>());
         deploymentProperties.put(PREFIX + ".javaOpts", "-Dtest=foo -Dbar=baz");
         AppDeploymentRequest appDeploymentRequest =
-                new AppDeploymentRequest(definition, new UrlResource("http://spring.io"), deploymentProperties);
+                new AppDeploymentRequest(definition, new UrlResource("https://spring.io"), deploymentProperties);
         commandBuilder.addJavaExecutionOptions(args, appDeploymentRequest);
     }
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).