### PR TITLE
Fix debug and inherit settings

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -54,14 +54,14 @@ public class LocalDeployerProperties {
 	 * {@literal deployer.*.local.inheritLogging=true}) or per individual application
 	 * (<em>i.e.</em> {@literal deployer.<app-name>.local.inheritLogging=true}).
 	 */
-	public static final String INHERIT_LOGGING = PREFIX + ".inheritLogging";
+	public static final String INHERIT_LOGGING = PREFIX + ".inherit-logging";
 
 	/**
 	 * Remote debugging property allowing one to specify port for the remote debug session.
 	 * Must be set per individual application (<em>i.e.</em>
 	 * {@literal deployer.<app-name>.local.debugPort=9999}).
 	 */
-	public static final String DEBUG_PORT = PREFIX + ".debugPort";
+	public static final String DEBUG_PORT = PREFIX + ".debug-port";
 
 	/**
 	 * Remote debugging property allowing one to specify if the startup of the application
@@ -69,7 +69,7 @@ public class LocalDeployerProperties {
 	 * 'y' or 'n'. Must be set per individual application (<em>i.e.</em>
 	 * {@literal deployer.<app-name>.local.debugSuspend=y}).
 	 */
-	public static final String DEBUG_SUSPEND = PREFIX + ".debugSuspend";
+	public static final String DEBUG_SUSPEND = PREFIX + ".debug-suspend";
 
 	private static final Logger logger = LoggerFactory.getLogger(LocalDeployerProperties.class);
 
@@ -122,7 +122,6 @@ public class LocalDeployerProperties {
 	 */
 	private boolean useSpringApplicationJson = true;
 
-
 	private PortRange portRange = new PortRange();
 
 	public static class PortRange {
@@ -163,6 +162,36 @@ public class LocalDeployerProperties {
 	 */
 	@Min(1)
 	private int maximumConcurrentTasks = 20;
+
+	private Integer debugPort;
+
+	private String debugSuspend;
+
+	private boolean inheritLogging;
+
+	public Integer getDebugPort() {
+		return debugPort;
+	}
+
+	public String getDebugSuspend() {
+		return debugSuspend;
+	}
+
+	public void setDebugSuspend(String debugSuspend) {
+		this.debugSuspend = debugSuspend;
+	}
+
+	public void setDebugPort(Integer debugPort) {
+		this.debugPort = debugPort;
+	}
+
+	public boolean isInheritLogging() {
+		return inheritLogging;
+	}
+
+	public void setInheritLogging(boolean inheritLogging) {
+		this.inheritLogging = inheritLogging;
+	}
 
 	public String getJavaCmd() {
 		return javaCmd;
@@ -224,7 +253,7 @@ public class LocalDeployerProperties {
 	public PortRange getPortRange() {
 		return portRange;
 	}
-	
+
 	public int getMaximumConcurrentTasks() {
 		return maximumConcurrentTasks;
 	}

--- a/spring-cloud-deployer-local/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-deployer-local/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,15 @@
+{
+  "hints": [
+    {
+      "name": "spring.cloud.deployer.local.debug-suspend",
+      "values": [
+        {
+          "value": "y"
+        },
+        {
+          "value": "n"
+        }
+      ]
+    }
+  ]
+}

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalDeployerPropertiesTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalDeployerPropertiesTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.local;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+public class LocalDeployerPropertiesTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+	@Test
+	public void defaultNoPropertiesSet() {
+		this.contextRunner
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				LocalDeployerProperties properties = context.getBean(LocalDeployerProperties.class);
+				assertThat(properties.getDebugPort()).isNull();
+				assertThat(properties.getDebugSuspend()).isNull();
+				assertThat(properties.isDeleteFilesOnExit()).isTrue();
+				assertThat(properties.getEnvVarsToInherit()).containsExactly("TMP", "LANG", "LANGUAGE", "LC_.*",
+							"PATH", "SPRING_APPLICATION_JSON");
+				assertThat(properties.isInheritLogging()).isFalse();
+				assertThat(properties.getJavaCmd()).contains("java");
+				assertThat(properties.getJavaOpts()).isNull();
+				assertThat(properties.getMaximumConcurrentTasks()).isEqualTo(20);
+				assertThat(properties.getPortRange()).isNotNull();
+				assertThat(properties.getPortRange().getLow()).isEqualTo(20000);
+				assertThat(properties.getPortRange().getHigh()).isEqualTo(61000);
+				assertThat(properties.getShutdownTimeout()).isEqualTo(30);
+				assertThat(properties.isUseSpringApplicationJson()).isTrue();
+			});
+	}
+
+	@Test
+	public void setAllProperties() {
+		this.contextRunner
+			.withInitializer(context -> {
+				Map<String, Object> map = new HashMap<>();
+				map.put("spring.cloud.deployer.local.debug-port", "8888");
+				map.put("spring.cloud.deployer.local.debug-suspend", "n");
+				map.put("spring.cloud.deployer.local.delete-files-on-exit", false);
+				map.put("spring.cloud.deployer.local.env-vars-to-inherit", "FOO,BAR");
+				map.put("spring.cloud.deployer.local.inherit-logging", true);
+				map.put("spring.cloud.deployer.local.java-cmd", "foobar1");
+				map.put("spring.cloud.deployer.local.java-opts", "foobar2");
+				map.put("spring.cloud.deployer.local.maximum-concurrent-tasks", 1234);
+				map.put("spring.cloud.deployer.local.port-range.low", 2345);
+				map.put("spring.cloud.deployer.local.port-range.high", 2346);
+				map.put("spring.cloud.deployer.local.shutdown-timeout", 3456);
+				map.put("spring.cloud.deployer.local.use-spring-application-json", false);
+
+				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
+					StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
+			})
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				LocalDeployerProperties properties = context.getBean(LocalDeployerProperties.class);
+				assertThat(properties.getDebugPort()).isEqualTo(8888);
+				assertThat(properties.getDebugSuspend()).isEqualTo("n");
+				assertThat(properties.isDeleteFilesOnExit()).isFalse();
+				assertThat(properties.getEnvVarsToInherit()).containsExactly("FOO", "BAR");
+				assertThat(properties.isInheritLogging()).isTrue();
+				assertThat(properties.getJavaCmd()).contains("foobar1");
+				assertThat(properties.getJavaOpts()).contains("foobar2");
+				assertThat(properties.getMaximumConcurrentTasks()).isEqualTo(1234);
+				assertThat(properties.getPortRange()).isNotNull();
+				assertThat(properties.getPortRange().getLow()).isEqualTo(2345);
+				assertThat(properties.getPortRange().getHigh()).isEqualTo(2346);
+				assertThat(properties.getShutdownTimeout()).isEqualTo(3456);
+				assertThat(properties.isUseSpringApplicationJson()).isFalse();
+			});
+	}
+
+
+	@Test
+	public void setAllPropertiesCamelCase() {
+		this.contextRunner
+			.withInitializer(context -> {
+				Map<String, Object> map = new HashMap<>();
+				map.put("spring.cloud.deployer.local.debugPort", "8888");
+				map.put("spring.cloud.deployer.local.debugSuspend", "n");
+				map.put("spring.cloud.deployer.local.deleteFilesOnExit", false);
+				map.put("spring.cloud.deployer.local.envVarsToInherit", "FOO,BAR");
+				map.put("spring.cloud.deployer.local.inheritLogging", true);
+				map.put("spring.cloud.deployer.local.javaCmd", "foobar1");
+				map.put("spring.cloud.deployer.local.javaOpts", "foobar2");
+				map.put("spring.cloud.deployer.local.maximumConcurrentTasks", 1234);
+				map.put("spring.cloud.deployer.local.portRange.low", 2345);
+				map.put("spring.cloud.deployer.local.portRange.high", 2346);
+				map.put("spring.cloud.deployer.local.shutdownTimeout", 3456);
+				map.put("spring.cloud.deployer.local.useSpringApplicationJson", false);
+
+				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
+					StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
+			})
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				LocalDeployerProperties properties = context.getBean(LocalDeployerProperties.class);
+				assertThat(properties.getDebugPort()).isEqualTo(8888);
+				assertThat(properties.getDebugSuspend()).isEqualTo("n");
+				assertThat(properties.isDeleteFilesOnExit()).isFalse();
+				assertThat(properties.getEnvVarsToInherit()).containsExactly("FOO", "BAR");
+				assertThat(properties.isInheritLogging()).isTrue();
+				assertThat(properties.getJavaCmd()).contains("foobar1");
+				assertThat(properties.getJavaOpts()).contains("foobar2");
+				assertThat(properties.getMaximumConcurrentTasks()).isEqualTo(1234);
+				assertThat(properties.getPortRange()).isNotNull();
+				assertThat(properties.getPortRange().getLow()).isEqualTo(2345);
+				assertThat(properties.getPortRange().getHigh()).isEqualTo(2346);
+				assertThat(properties.getShutdownTimeout()).isEqualTo(3456);
+				assertThat(properties.isUseSpringApplicationJson()).isFalse();
+			});
+	}
+
+	@EnableConfigurationProperties({ LocalDeployerProperties.class })
+	private static class Config1 {
+	}
+}


### PR DESCRIPTION
- Change original keys debugPort, debugSuspend and inheritLogging to
  a proper kebab-case keys, debug-port, debug-suspend and inherit-logging.
- Fix LocalDeployerProperties so that these keys can be properly binded
  and that keys actually go into boot metadata.
- When these are used from a deployment request, properly use boot's
  property Binder so that both camelCase and kebab-case work.
- Add debug-suspend to a additional-spring-configuration-metadata.json with
  hints `y` and `n` so that those will be picked as option set in UI.
- Various tests to see that all works.
- This commit will leave other properties use of camelCase vs. kebab-case
  unchanged as it's a bit larger topic.
- Fixes #160

NOTE: This will then break some skipper tests as there's 3 new deployment properties and we seem to check count returned for local deployer.

Here's example how these new properties will show up in UI:

![local-deployer-debug-options](https://user-images.githubusercontent.com/50398/60264734-d9bfdb80-98db-11e9-8d46-5598660c6991.png)
