### PR TITLE
Implement scaling for LocalAppDeployer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>2.1.0.M2</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
 	<properties>
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring-cloud-deployer.version>2.1.0.M2</spring-cloud-deployer.version>
+		<spring-cloud-deployer.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployerIntegrationTests.java
@@ -23,7 +23,6 @@ import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,9 +37,7 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -191,6 +188,17 @@ public class LocalAppDeployerIntegrationTests extends AbstractAppDeployerIntegra
 				Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
 		String logContent = appDeployer().getLog(deploymentId);
 		assertThat(logContent, containsString("Starting DeployerIntegrationTestApplication"));
+	}
+
+	// TODO: remove when these two are forced in tck tests
+	@Test
+	public void testScale() {
+		doTestScale(false);
+	}
+
+	@Test
+	public void testScaleWithIndex() {
+		doTestScale(true);
 	}
 
 	@Test


### PR DESCRIPTION
- Starting to keep more state within LocalAppDeployer so that
  when scale request comes in we can just deploy more apps and
  figure out new index.
- Scaling down simply removes apps per LIFO
- Shuffled things around not to duplicate too much code as deploy
  and scale shares a lot of code when starting apps.
- Manually hooked into existing tck tests for scaling as those
  are not yet globally enabled.
- Fixes #172