### PR TITLE
Make tests run on windows

### DIFF
--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalDeployerPropertiesTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalDeployerPropertiesTests.java
@@ -20,7 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.core.env.StandardEnvironment;
@@ -31,6 +34,7 @@ public class LocalDeployerPropertiesTests {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
 
 	@Test
+	@EnabledOnOs(OS.LINUX)
 	public void defaultNoPropertiesSet() {
 		this.contextRunner
 			.withUserConfiguration(Config1.class)
@@ -131,6 +135,44 @@ public class LocalDeployerPropertiesTests {
 				assertThat(properties.getPortRange().getHigh()).isEqualTo(2346);
 				assertThat(properties.getShutdownTimeout()).isEqualTo(3456);
 				assertThat(properties.isUseSpringApplicationJson()).isFalse();
+			});
+	}
+
+	@Test
+	@EnabledOnOs(OS.WINDOWS)
+	public void testOnWindows() {
+		this.contextRunner
+			.withInitializer(context -> {
+				Map<String, Object> map = new HashMap<>();
+				map.put("spring.cloud.deployer.local.working-directories-root", "file:/C:/tmp");
+				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
+					StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
+			})
+
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				LocalDeployerProperties properties = context.getBean(LocalDeployerProperties.class);
+				assertThat(properties.getWorkingDirectoriesRoot()).isNotNull();
+				assertThat(properties.getWorkingDirectoriesRoot().toString()).isEqualTo("C:\\tmp");
+			});
+	}
+
+	@Test
+	@EnabledOnOs(OS.LINUX)
+	public void testOnLinux() {
+		this.contextRunner
+			.withInitializer(context -> {
+				Map<String, Object> map = new HashMap<>();
+				map.put("spring.cloud.deployer.local.working-directories-root", "/tmp");
+
+				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
+					StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
+			})
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				LocalDeployerProperties properties = context.getBean(LocalDeployerProperties.class);
+				assertThat(properties.getWorkingDirectoriesRoot()).isNotNull();
+				assertThat(properties.getWorkingDirectoriesRoot().toString()).isEqualTo("/tmp");
 			});
 	}
 


### PR DESCRIPTION
- In LocalDeployerPropertiesTests move to junit5 and mark
  defaultNoPropertiesSet() to run on linux only.
- Add new tests for working-directories-root binding
  and do separate tests on linux and windows.