### PR TITLE
Run apps as docker containers in docker-compose

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -104,7 +104,7 @@ public abstract class AbstractLocalDeployerSupport {
 		Assert.notNull(localDeployerProperties, "LocalDeployerProperties must not be null");
 		this.localDeployerProperties = localDeployerProperties;
 		this.javaCommandBuilder = new JavaCommandBuilder(localDeployerProperties);
-		this.dockerCommandBuilder = new DockerCommandBuilder(localDeployerProperties.getDockerNetwork());
+		this.dockerCommandBuilder = new DockerCommandBuilder(localDeployerProperties.getDocker().getNetwork());
 		this.restTemplate = buildRestTemplate(localDeployerProperties);
 	}
 
@@ -133,7 +133,7 @@ public abstract class AbstractLocalDeployerSupport {
 	protected String buildRemoteDebugInstruction(LocalDeployerProperties deployerProperties, String deploymentId,
 			int instanceIndex, int port) {
 		String ds = "y";
-		if(StringUtils.hasText(deployerProperties.getDebugSuspend())) {
+		if (StringUtils.hasText(deployerProperties.getDebugSuspend())) {
 			ds = deployerProperties.getDebugSuspend();
 		}
 		StringBuilder debugCommandBuilder = new StringBuilder();
@@ -255,7 +255,7 @@ public abstract class AbstractLocalDeployerSupport {
 	 */
 	protected LocalDeployerProperties bindDeploymentProperties(Map<String, String> runtimeDeploymentProperties) {
 		LocalDeployerProperties copyOfDefaultProperties = new LocalDeployerProperties();
-		BeanUtils.copyProperties(this.localDeployerProperties, copyOfDefaultProperties );
+		BeanUtils.copyProperties(this.localDeployerProperties, copyOfDefaultProperties);
 		return new Binder(new MapConfigurationPropertySource(runtimeDeploymentProperties))
 				.bind(LocalDeployerProperties.PREFIX, Bindable.ofInstance(copyOfDefaultProperties))
 				.orElse(copyOfDefaultProperties);

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
@@ -60,6 +61,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Vinicius Carvalho
  * @author Michael Minella
  * @author David Turanski
+ * @author Christian Tzolov
  */
 public abstract class AbstractLocalDeployerSupport {
 
@@ -102,7 +104,7 @@ public abstract class AbstractLocalDeployerSupport {
 		Assert.notNull(localDeployerProperties, "LocalDeployerProperties must not be null");
 		this.localDeployerProperties = localDeployerProperties;
 		this.javaCommandBuilder = new JavaCommandBuilder(localDeployerProperties);
-		this.dockerCommandBuilder = new DockerCommandBuilder();
+		this.dockerCommandBuilder = new DockerCommandBuilder(localDeployerProperties.getDockerNetwork());
 		this.restTemplate = buildRestTemplate(localDeployerProperties);
 	}
 
@@ -201,6 +203,7 @@ public abstract class AbstractLocalDeployerSupport {
 		}
 
 		if (request.getResource() instanceof DockerResource) {
+			appPropertiesToUse.put("deployerId", deploymentId);
 			commands = this.dockerCommandBuilder.buildExecutionCommand(request, appPropertiesToUse, appInstanceNumber);
 		}
 		else {

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import org.springframework.util.StringUtils;
  * @author Henryk Konsek
  * @author Thomas Risberg
  * @author Michael Minella
+ * @author Christian Tzolov
  */
 public class DockerCommandBuilder implements CommandBuilder {
 
@@ -51,6 +52,11 @@ public class DockerCommandBuilder implements CommandBuilder {
 	public static final String DOCKER_CONTAINER_NAME_KEY = AppDeployer.PREFIX + "docker.container.name";
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
+	private String dockerNetwork;
+
+	public DockerCommandBuilder(String dockerNetwork) {
+		this.dockerNetwork = dockerNetwork;
+	}
 
 	@Override
 	public String[] buildExecutionCommand(AppDeploymentRequest request, Map<String, String> appInstanceEnv,
@@ -66,6 +72,10 @@ public class DockerCommandBuilder implements CommandBuilder {
 		List<String> commands = new ArrayList<>();
 		commands.add("docker");
 		commands.add("run");
+		if (StringUtils.hasText(this.dockerNetwork)) {
+			commands.add("--network");
+			commands.add(this.dockerNetwork);
+		}
 
 		// Add env vars
 		for (String env : appInstanceEnv.keySet()) {

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -170,6 +170,16 @@ public class LocalDeployerProperties {
 
 	private boolean inheritLogging;
 
+	private String dockerNetwork = "bridge";
+
+	public String getDockerNetwork() {
+		return dockerNetwork;
+	}
+
+	public void setDockerNetwork(String dockerNetwork) {
+		this.dockerNetwork = dockerNetwork;
+	}
+
 	public Integer getDebugPort() {
 		return debugPort;
 	}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -170,14 +170,22 @@ public class LocalDeployerProperties {
 
 	private boolean inheritLogging;
 
-	private String dockerNetwork = "bridge";
+	private Docker docker = new Docker();
 
-	public String getDockerNetwork() {
-		return dockerNetwork;
+	public static class Docker {
+		private String network = "bridge";
+
+		public String getNetwork() {
+			return network;
+		}
+
+		public void setNetwork(String network) {
+			this.network = network;
+		}
 	}
 
-	public void setDockerNetwork(String dockerNetwork) {
-		this.dockerNetwork = dockerNetwork;
+	public Docker getDocker() {
+		return docker;
 	}
 
 	public Integer getDebugPort() {

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilderTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilderTests.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertThat;
  */
 public class DockerCommandBuilderTests {
 
-	private DockerCommandBuilder commandBuilder = new DockerCommandBuilder();
+	private DockerCommandBuilder commandBuilder = new DockerCommandBuilder(null);
 
 	@Test
 	public void testContainerName() {
@@ -50,6 +50,18 @@ public class DockerCommandBuilderTests {
 		String[] command = commandBuilder.buildExecutionCommand(request, Collections.emptyMap(), Optional.of(1));
 
 		assertThat(command, arrayContaining("docker", "run", "--name=gogo-1", "foo/bar"));
+	}
+
+	@Test
+	public void testContainerNameWithDockerNetwork() {
+		AppDefinition appDefinition = new AppDefinition("foo", null);
+		Resource resource = new DockerResource("foo/bar");
+		Map<String, String> deploymentProperties = Collections.singletonMap(DockerCommandBuilder.DOCKER_CONTAINER_NAME_KEY, "gogo");
+		AppDeploymentRequest request = new AppDeploymentRequest(appDefinition, resource, deploymentProperties);
+		String[] command = new DockerCommandBuilder("spring-cloud-dataflow-server_default")
+				.buildExecutionCommand(request, Collections.emptyMap(), Optional.of(1));
+
+		assertThat(command, arrayContaining("docker", "run", "--network", "spring-cloud-dataflow-server_default",  "--name=gogo-1", "foo/bar"));
 	}
 
 	@Test

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalDeployerPropertiesTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalDeployerPropertiesTests.java
@@ -54,6 +54,7 @@ public class LocalDeployerPropertiesTests {
 				assertThat(properties.getPortRange().getHigh()).isEqualTo(61000);
 				assertThat(properties.getShutdownTimeout()).isEqualTo(30);
 				assertThat(properties.isUseSpringApplicationJson()).isTrue();
+				assertThat(properties.getDocker().getNetwork()).isEqualTo("bridge");
 			});
 	}
 
@@ -74,6 +75,7 @@ public class LocalDeployerPropertiesTests {
 				map.put("spring.cloud.deployer.local.port-range.high", 2346);
 				map.put("spring.cloud.deployer.local.shutdown-timeout", 3456);
 				map.put("spring.cloud.deployer.local.use-spring-application-json", false);
+				map.put("spring.cloud.deployer.local.docker.network", "spring-cloud-dataflow-server_default");
 
 				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
 					StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
@@ -94,6 +96,7 @@ public class LocalDeployerPropertiesTests {
 				assertThat(properties.getPortRange().getHigh()).isEqualTo(2346);
 				assertThat(properties.getShutdownTimeout()).isEqualTo(3456);
 				assertThat(properties.isUseSpringApplicationJson()).isFalse();
+				assertThat(properties.getDocker().getNetwork()).isEqualTo("spring-cloud-dataflow-server_default");
 			});
 	}
 
@@ -115,6 +118,7 @@ public class LocalDeployerPropertiesTests {
 				map.put("spring.cloud.deployer.local.portRange.high", 2346);
 				map.put("spring.cloud.deployer.local.shutdownTimeout", 3456);
 				map.put("spring.cloud.deployer.local.useSpringApplicationJson", false);
+				map.put("spring.cloud.deployer.local.docker.network", "spring-cloud-dataflow-server_default");
 
 				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
 					StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
@@ -135,6 +139,7 @@ public class LocalDeployerPropertiesTests {
 				assertThat(properties.getPortRange().getHigh()).isEqualTo(2346);
 				assertThat(properties.getShutdownTimeout()).isEqualTo(3456);
 				assertThat(properties.isUseSpringApplicationJson()).isFalse();
+				assertThat(properties.getDocker().getNetwork()).isEqualTo("spring-cloud-dataflow-server_default");
 			});
 	}
 


### PR DESCRIPTION
 - The spring.cloud.deployer.local.dockerNetwork allows setting the container network. When provided it adds --network <scdf network name> to the DockerCommandBuilder to ensure that the deployed app containers are connected to the network created by the docker-compose (note that the -p project-name). For default docker-compose installations set the dockerNetwork to spring-cloud-dataflow-server_default
 - Set the deployment-id as docker container name of the deployed app.
 - Change the AppInstance URL to <deployement-id>:<app-port> (the URL uses the local/skipper IP otherwise).
 - Backward compatible with not docker compose local installations

Related to: https://github.com/spring-cloud/spring-cloud-dataflow/issues/3966
Related to: https://github.com/spring-cloud/spring-cloud-dataflow/issues/3643

Based on: https://docs.google.com/document/d/1gZrqF6QCVqdYVJ8LAModPr_O0dJUSGW-KSFAI1tuYcE/edit?usp=sharing