### PR TITLE
Add manual copy of LocalDeployerProperties

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -34,7 +34,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
@@ -254,8 +253,7 @@ public abstract class AbstractLocalDeployerSupport {
 	 * @return merged deployer properties
 	 */
 	protected LocalDeployerProperties bindDeploymentProperties(Map<String, String> runtimeDeploymentProperties) {
-		LocalDeployerProperties copyOfDefaultProperties = new LocalDeployerProperties();
-		BeanUtils.copyProperties(this.localDeployerProperties, copyOfDefaultProperties);
+		LocalDeployerProperties copyOfDefaultProperties = new LocalDeployerProperties(this.localDeployerProperties);
 		return new Binder(new MapConfigurationPropertySource(runtimeDeploymentProperties))
 				.bind(LocalDeployerProperties.PREFIX, Bindable.ofInstance(copyOfDefaultProperties))
 				.orElse(copyOfDefaultProperties);

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/JavaCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/JavaCommandBuilder.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
@@ -113,8 +112,7 @@ public class JavaCommandBuilder implements CommandBuilder {
 	 * @return merged deployer properties
 	 */
 	protected LocalDeployerProperties bindDeploymentProperties(Map<String, String> runtimeDeploymentProperties) {
-		LocalDeployerProperties copyOfDefaultProperties = new LocalDeployerProperties();
-		BeanUtils.copyProperties(this.properties, copyOfDefaultProperties );
+		LocalDeployerProperties copyOfDefaultProperties = new LocalDeployerProperties(this.properties);
 		return new Binder(new MapConfigurationPropertySource(runtimeDeploymentProperties))
 				.bind(LocalDeployerProperties.PREFIX, Bindable.ofInstance(copyOfDefaultProperties))
 				.orElse(copyOfDefaultProperties);

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ package org.springframework.cloud.deployer.spi.local;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 
 import javax.validation.constraints.Min;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,25 +50,26 @@ public class LocalDeployerProperties {
 	public static final String PREFIX = "spring.cloud.deployer.local";
 
 	/**
-	 * Deployer property allowing logging to be redirected to the output stream of the process
-	 * that triggered child process. Could be set per the entire deployment (<em>i.e.</em>
-	 * {@literal deployer.*.local.inheritLogging=true}) or per individual application
-	 * (<em>i.e.</em> {@literal deployer.<app-name>.local.inheritLogging=true}).
+	 * Deployer property allowing logging to be redirected to the output stream of
+	 * the process that triggered child process. Could be set per the entire
+	 * deployment (<em>i.e.</em> {@literal deployer.*.local.inheritLogging=true}) or
+	 * per individual application (<em>i.e.</em>
+	 * {@literal deployer.<app-name>.local.inheritLogging=true}).
 	 */
 	public static final String INHERIT_LOGGING = PREFIX + ".inherit-logging";
 
 	/**
-	 * Remote debugging property allowing one to specify port for the remote debug session.
-	 * Must be set per individual application (<em>i.e.</em>
+	 * Remote debugging property allowing one to specify port for the remote debug
+	 * session. Must be set per individual application (<em>i.e.</em>
 	 * {@literal deployer.<app-name>.local.debugPort=9999}).
 	 */
 	public static final String DEBUG_PORT = PREFIX + ".debug-port";
 
 	/**
-	 * Remote debugging property allowing one to specify if the startup of the application
-	 * should be suspended until remote debug session is established. Values must be either
-	 * 'y' or 'n'. Must be set per individual application (<em>i.e.</em>
-	 * {@literal deployer.<app-name>.local.debugSuspend=y}).
+	 * Remote debugging property allowing one to specify if the startup of the
+	 * application should be suspended until remote debug session is established.
+	 * Values must be either 'y' or 'n'. Must be set per individual application
+	 * (<em>i.e.</em> {@literal deployer.<app-name>.local.debugSuspend=y}).
 	 */
 	public static final String DEBUG_SUSPEND = PREFIX + ".debug-suspend";
 
@@ -76,7 +77,8 @@ public class LocalDeployerProperties {
 
 	private static final String JAVA_COMMAND = LocalDeployerUtils.isWindows() ? "java.exe" : "java";
 
-	// looks like some windows systems uses 'Path' but processbuilder give it as 'PATH'
+	// looks like some windows systems uses 'Path' but processbuilder give it as
+	// 'PATH'
 	private static final String[] ENV_VARS_TO_INHERIT_DEFAULTS_WIN = { "TMP", "TEMP", "PATH", "Path",
 			AbstractLocalDeployerSupport.SPRING_APPLICATION_JSON };
 
@@ -94,8 +96,8 @@ public class LocalDeployerProperties {
 	private boolean deleteFilesOnExit = true;
 
 	/**
-	 * Array of regular expression patterns for environment variables that should be passed to
-	 * launched applications.
+	 * Array of regular expression patterns for environment variables that should be
+	 * passed to launched applications.
 	 */
 	private String[] envVarsToInherit = LocalDeployerUtils.isWindows() ? ENV_VARS_TO_INHERIT_DEFAULTS_WIN
 			: ENV_VARS_TO_INHERIT_DEFAULTS_OTHER;
@@ -106,8 +108,9 @@ public class LocalDeployerProperties {
 	private String javaCmd = deduceJavaCommand();
 
 	/**
-	 * Maximum number of seconds to wait for application shutdown. via the {@code /shutdown}
-	 * endpoint. A timeout value of 0 specifies an infinite timeout. Default is 30 seconds.
+	 * Maximum number of seconds to wait for application shutdown. via the
+	 * {@code /shutdown} endpoint. A timeout value of 0 specifies an infinite
+	 * timeout. Default is 30 seconds.
 	 */
 	@Min(-1)
 	private int shutdownTimeout = 30;
@@ -118,12 +121,34 @@ public class LocalDeployerProperties {
 	private String javaOpts;
 
 	/**
-	 * Flag to indicate whether application properties are passed as command line args or in a
-	 * SPRING_APPLICATION_JSON environment variable. Default value is {@code true}.
+	 * Flag to indicate whether application properties are passed as command line
+	 * args or in a SPRING_APPLICATION_JSON environment variable. Default value is
+	 * {@code true}.
 	 */
 	private boolean useSpringApplicationJson = true;
 
 	private PortRange portRange = new PortRange();
+
+	public LocalDeployerProperties() {
+	}
+
+	public LocalDeployerProperties(LocalDeployerProperties from) {
+		this.debugPort = from.getDebugPort();
+		this.debugSuspend = from.getDebugSuspend();
+		this.deleteFilesOnExit = from.isDeleteFilesOnExit();
+		this.docker.network = from.getDocker().getNetwork();
+		this.envVarsToInherit = new String[from.getEnvVarsToInherit().length];
+		System.arraycopy(from.getEnvVarsToInherit(), 0, this.envVarsToInherit, 0, from.getEnvVarsToInherit().length);
+		this.inheritLogging = from.isInheritLogging();
+		this.javaCmd = from.getJavaCmd();
+		this.javaOpts = from.getJavaOpts();
+		this.maximumConcurrentTasks = from.getMaximumConcurrentTasks();
+		this.portRange.high = from.getPortRange().getHigh();
+		this.portRange.low = from.getPortRange().getLow();
+		this.shutdownTimeout = from.getShutdownTimeout();
+		this.useSpringApplicationJson = from.isUseSpringApplicationJson();
+		this.workingDirectoriesRoot = Paths.get(from.getWorkingDirectoriesRoot().toUri());
+	}
 
 	public static class PortRange {
 
@@ -157,7 +182,38 @@ public class LocalDeployerProperties {
 		public String toString() {
 			return "{ low=" + low + ", high=" + high + '}';
 		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + high;
+			result = prime * result + low;
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			PortRange other = (PortRange) obj;
+			if (high != other.high) {
+				return false;
+			}
+			if (low != other.low) {
+				return false;
+			}
+			return true;
+		}
 	}
+
 	/**
 	 * The maximum concurrent tasks allowed for this platform instance.
 	 */
@@ -181,6 +237,37 @@ public class LocalDeployerProperties {
 
 		public void setNetwork(String network) {
 			this.network = network;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((network == null) ? 0 : network.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			Docker other = (Docker) obj;
+			if (network == null) {
+				if (other.network != null) {
+					return false;
+				}
+			}
+			else if (!network.equals(other.network)) {
+				return false;
+			}
+			return true;
 		}
 	}
 
@@ -305,10 +392,116 @@ public class LocalDeployerProperties {
 
 	@Override
 	public String toString() {
-		return new ToStringCreator(this)
-				.append("workingDirectoriesRoot", this.workingDirectoriesRoot)
-				.append("javaOpts", this.javaOpts)
-				.append("envVarsToInherit", this.envVarsToInherit)
-				.toString();
+		return new ToStringCreator(this).append("workingDirectoriesRoot", this.workingDirectoriesRoot)
+				.append("javaOpts", this.javaOpts).append("envVarsToInherit", this.envVarsToInherit).toString();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((debugPort == null) ? 0 : debugPort.hashCode());
+		result = prime * result + ((debugSuspend == null) ? 0 : debugSuspend.hashCode());
+		result = prime * result + (deleteFilesOnExit ? 1231 : 1237);
+		result = prime * result + ((docker == null) ? 0 : docker.hashCode());
+		result = prime * result + Arrays.hashCode(envVarsToInherit);
+		result = prime * result + (inheritLogging ? 1231 : 1237);
+		result = prime * result + ((javaCmd == null) ? 0 : javaCmd.hashCode());
+		result = prime * result + ((javaOpts == null) ? 0 : javaOpts.hashCode());
+		result = prime * result + maximumConcurrentTasks;
+		result = prime * result + ((portRange == null) ? 0 : portRange.hashCode());
+		result = prime * result + shutdownTimeout;
+		result = prime * result + (useSpringApplicationJson ? 1231 : 1237);
+		result = prime * result + ((workingDirectoriesRoot == null) ? 0 : workingDirectoriesRoot.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		LocalDeployerProperties other = (LocalDeployerProperties) obj;
+		if (debugPort == null) {
+			if (other.debugPort != null) {
+				return false;
+			}
+		}
+		else if (!debugPort.equals(other.debugPort)) {
+			return false;
+		}
+		if (debugSuspend == null) {
+			if (other.debugSuspend != null) {
+				return false;
+			}
+		}
+		else if (!debugSuspend.equals(other.debugSuspend)) {
+			return false;
+		}
+		if (deleteFilesOnExit != other.deleteFilesOnExit) {
+			return false;
+		}
+		if (docker == null) {
+			if (other.docker != null) {
+				return false;
+			}
+		}
+		else if (!docker.equals(other.docker)) {
+			return false;
+		}
+		if (!Arrays.equals(envVarsToInherit, other.envVarsToInherit)) {
+			return false;
+		}
+		if (inheritLogging != other.inheritLogging) {
+			return false;
+		}
+		if (javaCmd == null) {
+			if (other.javaCmd != null) {
+				return false;
+			}
+		}
+		else if (!javaCmd.equals(other.javaCmd)) {
+			return false;
+		}
+		if (javaOpts == null) {
+			if (other.javaOpts != null) {
+				return false;
+			}
+		}
+		else if (!javaOpts.equals(other.javaOpts)) {
+			return false;
+		}
+		if (maximumConcurrentTasks != other.maximumConcurrentTasks) {
+			return false;
+		}
+		if (portRange == null) {
+			if (other.portRange != null) {
+				return false;
+			}
+		}
+		else if (!portRange.equals(other.portRange)) {
+			return false;
+		}
+		if (shutdownTimeout != other.shutdownTimeout) {
+			return false;
+		}
+		if (useSpringApplicationJson != other.useSpringApplicationJson) {
+			return false;
+		}
+		if (workingDirectoriesRoot == null) {
+			if (other.workingDirectoriesRoot != null) {
+				return false;
+			}
+		}
+		else if (!workingDirectoriesRoot.equals(other.workingDirectoriesRoot)) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalDeployerPropertiesTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalDeployerPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,7 @@
  */
 package org.springframework.cloud.deployer.spi.local;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,6 +27,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalDeployerPropertiesTests {
 
@@ -179,6 +180,32 @@ public class LocalDeployerPropertiesTests {
 				assertThat(properties.getWorkingDirectoriesRoot()).isNotNull();
 				assertThat(properties.getWorkingDirectoriesRoot().toString()).isEqualTo("/tmp");
 			});
+	}
+
+	@Test
+	@EnabledOnOs(OS.LINUX)
+	public void testCopyProperties() {
+		LocalDeployerProperties from = new LocalDeployerProperties();
+		LocalDeployerProperties to = new LocalDeployerProperties(from);
+		assertThat(from).isEqualTo(to);
+
+		from = new LocalDeployerProperties();
+		from.setDebugPort(1234);
+		from.setDebugSuspend("debugSuspend");
+		from.getDocker().setNetwork("network");
+		from.setDeleteFilesOnExit(true);
+		from.setEnvVarsToInherit(new String[]{"foobar"});
+		from.setInheritLogging(false);
+		from.setJavaCmd("javaCmd");
+		from.setJavaOpts("javaOpts");
+		from.setMaximumConcurrentTasks(234);
+		from.getPortRange().setHigh(2345);
+		from.getPortRange().setLow(2344);
+		from.setShutdownTimeout(345);
+		from.setUseSpringApplicationJson(false);
+		from.setWorkingDirectoriesRoot(Paths.get("/first"));
+		to = new LocalDeployerProperties(from);
+		assertThat(from).isEqualTo(to);
 	}
 
 	@EnableConfigurationProperties({ LocalDeployerProperties.class })


### PR DESCRIPTION
- Move away from BeanUtils.copyProperties to
  manually copy LocalDeployerProperties as
  its nested structure.
- Fixes #190