### PR TITLE
Add startup/health probes for stream apps

### DIFF
--- a/spring-cloud-deployer-local/pom.xml
+++ b/spring-cloud-deployer-local/pom.xml
@@ -57,6 +57,11 @@
 			<artifactId>spring-cloud-deployer-spi-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/HttpProbeExecutor.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/HttpProbeExecutor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.local;
+
+import java.net.URI;
+import java.net.URL;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties.HttpProbe;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+public class HttpProbeExecutor {
+
+	private static final Logger logger = LoggerFactory.getLogger(HttpProbeExecutor.class);
+    private final RestTemplate restTemplate;
+    private final URI uri;
+
+    public HttpProbeExecutor(RestTemplate restTemplate, URI uri) {
+        this.restTemplate = restTemplate;
+        this.uri = uri;
+    }
+
+    public static HttpProbeExecutor from(URL baseUrl, HttpProbe httpProbe) {
+        URI base = null;
+        try {
+            base = baseUrl.toURI();
+        } catch (Exception e) {
+        }
+        if (httpProbe == null || httpProbe.getPath() == null || base == null) {
+            return null;
+        }
+        DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory(base.toString());
+        uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+        URI uri = uriBuilderFactory.builder().path("{path}").build(httpProbe.getPath());
+        return new HttpProbeExecutor(new RestTemplate(), uri);
+    }
+
+    public boolean probe() {
+        try {
+            logger.info("Probing for {}", this.uri);
+            ResponseEntity<Void> response = restTemplate.getForEntity(uri, Void.class);
+            HttpStatus statusCode = response.getStatusCode();
+            boolean ok = statusCode.is2xxSuccessful();
+            if (!ok) {
+                logger.info("Probe for {} returned {}", this.uri, statusCode);
+            }
+            return ok;
+        } catch (Exception e) {
+            logger.trace("Probe error for {}", this.uri, e);
+        }
+        return false;
+    }
+}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/HttpProbeExecutor.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/HttpProbeExecutor.java
@@ -27,6 +27,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
+/**
+ * Simple probe executor using rest endpoints.
+ *
+ * @author Janne Valkealahti
+ *
+ */
 public class HttpProbeExecutor {
 
 	private static final Logger logger = LoggerFactory.getLogger(HttpProbeExecutor.class);

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -372,6 +372,39 @@ public class LocalDeployerProperties {
 		this.maximumConcurrentTasks = maximumConcurrentTasks;
 	}
 
+	private HttpProbe startupProbe = new HttpProbe();
+	private HttpProbe healthProbe = new HttpProbe();
+
+	public HttpProbe getStartupProbe() {
+		return startupProbe;
+	}
+
+	public void setStartupProbe(HttpProbe startupProbe) {
+		this.startupProbe = startupProbe;
+	}
+
+	public HttpProbe getHealthProbe() {
+		return healthProbe;
+	}
+
+	public void setHealthProbe(HttpProbe healthProbe) {
+		this.healthProbe = healthProbe;
+	}
+
+	public static class HttpProbe {
+
+		/** Path to check as a probe */
+		private String path;
+
+		public String getPath() {
+			return path;
+		}
+
+		public void setPath(String path) {
+			this.path = path;
+		}
+	}
+
 	private String deduceJavaCommand() {
 		String javaExecutablePath = JAVA_COMMAND;
 		String javaHome = System.getProperty("java.home");

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalDeployerPropertiesTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/LocalDeployerPropertiesTests.java
@@ -56,6 +56,10 @@ public class LocalDeployerPropertiesTests {
 				assertThat(properties.getShutdownTimeout()).isEqualTo(30);
 				assertThat(properties.isUseSpringApplicationJson()).isTrue();
 				assertThat(properties.getDocker().getNetwork()).isEqualTo("bridge");
+				assertThat(properties.getStartupProbe()).isNotNull();
+				assertThat(properties.getStartupProbe().getPath()).isNull();
+				assertThat(properties.getHealthProbe()).isNotNull();
+				assertThat(properties.getHealthProbe().getPath()).isNull();
 			});
 	}
 
@@ -77,6 +81,8 @@ public class LocalDeployerPropertiesTests {
 				map.put("spring.cloud.deployer.local.shutdown-timeout", 3456);
 				map.put("spring.cloud.deployer.local.use-spring-application-json", false);
 				map.put("spring.cloud.deployer.local.docker.network", "spring-cloud-dataflow-server_default");
+				map.put("spring.cloud.deployer.local.startup-probe.path", "/path1");
+				map.put("spring.cloud.deployer.local.health-probe.path", "/path2");
 
 				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
 					StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
@@ -98,6 +104,8 @@ public class LocalDeployerPropertiesTests {
 				assertThat(properties.getShutdownTimeout()).isEqualTo(3456);
 				assertThat(properties.isUseSpringApplicationJson()).isFalse();
 				assertThat(properties.getDocker().getNetwork()).isEqualTo("spring-cloud-dataflow-server_default");
+				assertThat(properties.getStartupProbe().getPath()).isEqualTo("/path1");
+				assertThat(properties.getHealthProbe().getPath()).isEqualTo("/path2");
 			});
 	}
 


### PR DESCRIPTION
- Adding an optional startup probe which simply checks
  2xx return code to mark when new app goes from deploying
  to deployed.
- Adding an optional health probe which simply checks
  2xx return code to mark when running app is marked either
  deployed or failed.
- Essentially adding `startup-probe.path` and `health-probe.path`
  with very minimal functionality but allows to easily add
  more features in future if needed.
- Together these allow to do failed stream update locally as
  previously it has only been possible in cf/k8s.
- Fixes #189