### PR TITLE
Use both stderr and stdout

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -253,10 +253,13 @@ public class LocalAppDeployer extends AbstractLocalDeployerSupport implements Ap
 			for (AppInstance instance : instances) {
 				String stderr = instance.getStdErr();
 				if (StringUtils.hasText(stderr)) {
+					stringBuilder.append("stderr:\n");
 					stringBuilder.append(stderr);
 				}
-				else {
-					stringBuilder.append(instance.getStdOut());
+				String stdout = instance.getStdOut();
+				if (StringUtils.hasText(stdout)) {
+					stringBuilder.append("stdout:\n");
+					stringBuilder.append(stdout);
 				}
 			}
 		}

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncher.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalTaskLauncher.java
@@ -179,8 +179,18 @@ public class LocalTaskLauncher extends AbstractLocalDeployerSupport implements T
 	public String getLog(String id) {
 		TaskInstance instance = running.get(id);
 		if (instance != null) {
+			StringBuilder stringBuilder = new StringBuilder();
 			String stderr = instance.getStdErr();
-			return (StringUtils.hasText(stderr)) ? stderr : instance.getStdOut();
+			if (StringUtils.hasText(stderr)) {
+				stringBuilder.append("stderr:\n");
+				stringBuilder.append(stderr);
+			}
+			String stdout = instance.getStdOut();
+			if (StringUtils.hasText(stdout)) {
+				stringBuilder.append("stdout:\n");
+				stringBuilder.append(stdout);
+			}
+			return stringBuilder.toString();
 		}
 		else {
 			return "Log could not be retrieved as the task instance is not running.";


### PR DESCRIPTION
- When getting logs for stream and task apps we used
  to just read stderr if it had some content which
  is a bit problematic as stderr may have some content
  which is not a real error.
- This i.e. happens with JAVA_TOOL_OPTIONS env variable.
- Now simply getting both.
- Fixes #193