### PR TITLE
Use deployerId as default docker container name

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -103,7 +103,8 @@ public abstract class AbstractLocalDeployerSupport {
 		Assert.notNull(localDeployerProperties, "LocalDeployerProperties must not be null");
 		this.localDeployerProperties = localDeployerProperties;
 		this.javaCommandBuilder = new JavaCommandBuilder(localDeployerProperties);
-		this.dockerCommandBuilder = new DockerCommandBuilder(localDeployerProperties.getDocker().getNetwork());
+		this.dockerCommandBuilder = new DockerCommandBuilder(localDeployerProperties.getDocker().getNetwork(),
+				localDeployerProperties.getDocker().isDeleteContainerOnExit());
 		this.restTemplate = buildRestTemplate(localDeployerProperties);
 	}
 

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilder.java
@@ -52,10 +52,12 @@ public class DockerCommandBuilder implements CommandBuilder {
 	public static final String DOCKER_CONTAINER_NAME_KEY = AppDeployer.PREFIX + "docker.container.name";
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
-	private String dockerNetwork;
+	private final String dockerNetwork;
+	private final boolean deleteContainerOnExit;
 
-	public DockerCommandBuilder(String dockerNetwork) {
+	public DockerCommandBuilder(String dockerNetwork, boolean deleteContainerOnExit) {
 		this.dockerNetwork = dockerNetwork;
+		this.deleteContainerOnExit = deleteContainerOnExit;
 	}
 
 	@Override
@@ -76,6 +78,9 @@ public class DockerCommandBuilder implements CommandBuilder {
 			commands.add("--network");
 			commands.add(this.dockerNetwork);
 		}
+		if (this.deleteContainerOnExit) {
+			commands.add("--rm");
+		}
 
 		// Add env vars
 		for (String env : appInstanceEnv.keySet()) {
@@ -91,6 +96,10 @@ public class DockerCommandBuilder implements CommandBuilder {
 			} else {
 				commands.add(String.format("--name=%s", request.getDeploymentProperties().get(DOCKER_CONTAINER_NAME_KEY)));
 			}
+		} else {
+			String group = request.getDeploymentProperties().get(AppDeployer.GROUP_PROPERTY_KEY);
+			String deploymentId = String.format("%s.%s", group, request.getDefinition().getName());
+			commands.add(String.format("--name=%s", deploymentId));
 		}
 
 		DockerResource dockerResource = (DockerResource) request.getResource();

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalDeployerProperties.java
@@ -231,12 +231,22 @@ public class LocalDeployerProperties {
 	public static class Docker {
 		private String network = "bridge";
 
+		private boolean deleteContainerOnExit = true;
+
 		public String getNetwork() {
 			return network;
 		}
 
 		public void setNetwork(String network) {
 			this.network = network;
+		}
+
+		public boolean isDeleteContainerOnExit() {
+			return deleteContainerOnExit;
+		}
+
+		public void setDeleteContainerOnExit(boolean deleteContainerOnExit) {
+			this.deleteContainerOnExit = deleteContainerOnExit;
 		}
 
 		@Override

--- a/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilderTests.java
+++ b/spring-cloud-deployer-local/src/test/java/org/springframework/cloud/deployer/spi/local/DockerCommandBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,10 +36,11 @@ import static org.junit.Assert.assertThat;
  * Unit tests for {@link DockerCommandBuilder}.
  *
  * @author Eric Bottard
+ * @author Christian Tzolov
  */
 public class DockerCommandBuilderTests {
 
-	private DockerCommandBuilder commandBuilder = new DockerCommandBuilder(null);
+	private DockerCommandBuilder commandBuilder = new DockerCommandBuilder(null, true);
 
 	@Test
 	public void testContainerName() {
@@ -49,7 +50,7 @@ public class DockerCommandBuilderTests {
 		AppDeploymentRequest request = new AppDeploymentRequest(appDefinition, resource, deploymentProperties);
 		String[] command = commandBuilder.buildExecutionCommand(request, Collections.emptyMap(), Optional.of(1));
 
-		assertThat(command, arrayContaining("docker", "run", "--name=gogo-1", "foo/bar"));
+		assertThat(command, arrayContaining("docker", "run", "--rm", "--name=gogo-1", "foo/bar"));
 	}
 
 	@Test
@@ -58,7 +59,19 @@ public class DockerCommandBuilderTests {
 		Resource resource = new DockerResource("foo/bar");
 		Map<String, String> deploymentProperties = Collections.singletonMap(DockerCommandBuilder.DOCKER_CONTAINER_NAME_KEY, "gogo");
 		AppDeploymentRequest request = new AppDeploymentRequest(appDefinition, resource, deploymentProperties);
-		String[] command = new DockerCommandBuilder("spring-cloud-dataflow-server_default")
+		String[] command = new DockerCommandBuilder("spring-cloud-dataflow-server_default", true)
+				.buildExecutionCommand(request, Collections.emptyMap(), Optional.of(1));
+
+		assertThat(command, arrayContaining("docker", "run", "--network", "spring-cloud-dataflow-server_default",  "--rm", "--name=gogo-1", "foo/bar"));
+	}
+
+	@Test
+	public void testContainerNameWithDockerNetworkAndKeepContainers() {
+		AppDefinition appDefinition = new AppDefinition("foo", null);
+		Resource resource = new DockerResource("foo/bar");
+		Map<String, String> deploymentProperties = Collections.singletonMap(DockerCommandBuilder.DOCKER_CONTAINER_NAME_KEY, "gogo");
+		AppDeploymentRequest request = new AppDeploymentRequest(appDefinition, resource, deploymentProperties);
+		String[] command = new DockerCommandBuilder("spring-cloud-dataflow-server_default", false)
 				.buildExecutionCommand(request, Collections.emptyMap(), Optional.of(1));
 
 		assertThat(command, arrayContaining("docker", "run", "--network", "spring-cloud-dataflow-server_default",  "--name=gogo-1", "foo/bar"));


### PR DESCRIPTION
 - if the DOCKER_CONTAINER_NAME_KEY is not explicitly set use the dockerId for container name.
 - By default remove the docker containers on exist.
 - Add a docker.deleteContainerOnExit property to control the removal of stopped containers. Set to true by default.

 Related to: spring-cloud/spring-cloud-dataflow#3966
 Related to: spring-cloud/spring-cloud-dataflow#3643
 Follow up of: https://github.com/spring-cloud/spring-cloud-deployer-local/commit/71a8153b2c46ba10b35ebb5af274724eab6d7b08