### PR TITLE
Prevent logging Env. Variables

### DIFF
--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/AbstractLocalDeployerSupport.java
@@ -177,8 +177,8 @@ public abstract class AbstractLocalDeployerSupport {
 						localDeployerProperties, debugAddressOption);
 
 		logger.info(String.format("Command to be executed: %s", String.join(" ", builder.command())));
-		logger.debug(String.format("Environment Variables to be used : %s", builder.environment().entrySet().stream()
-				.map(entry -> entry.getKey() + " : " + entry.getValue()).collect(Collectors.joining(", "))));
+		//logger.debug(String.format("Environment Variables to be used : %s", builder.environment().entrySet().stream()
+		//		.map(entry -> entry.getKey() + " : " + entry.getValue()).collect(Collectors.joining(", "))));
 		return builder;
 	}
 


### PR DESCRIPTION
   The way that Task (And Task Launcher) handle and use env. variables brings hight risk to expose
   sensitive information. Therefore it is safer not to list variables's values in any log level.